### PR TITLE
Some enhancements for rtt_ros_integration

### DIFF
--- a/rtt_rosnode/cmake/GenerateRTTtypekit.cmake
+++ b/rtt_rosnode/cmake/GenerateRTTtypekit.cmake
@@ -6,11 +6,7 @@ if (NOT OROCOS-RTT_FOUND)
   message(FATAL_ERROR "\n   RTT not found. Is the version correct? Use the CMAKE_PREFIX_PATH cmake or environment variable to point to the installation directory of RTT.")
 else()
   include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake)
-  add_definitions( -DRTT_COMPONENT )
 endif()
-set(ROS_BUILD_TYPE MinSizeRel)
-set(CMAKE_BUILD_TYPE MinSizeRel)
-include(AddFileDependencies)
 
 macro(rosbuild_get_msgs_external package msgs)
   rosbuild_find_ros_package(${package})
@@ -30,6 +26,10 @@ endmacro(rosbuild_get_msgs_external)
 
 
 function(ros_generate_rtt_typekit package)
+  set(ROS_BUILD_TYPE MinSizeRel)
+  set(CMAKE_BUILD_TYPE MinSizeRel)
+  include(AddFileDependencies)
+  add_definitions( -DRTT_COMPONENT )
 
   rosbuild_find_ros_package(rtt_rosnode)
 

--- a/rtt_rosnode/src/ros_msg_transporter.hpp
+++ b/rtt_rosnode/src/ros_msg_transporter.hpp
@@ -93,13 +93,22 @@ namespace ros_integration {
 	std::stringstream namestr;
 	gethostname(hostname, sizeof(hostname));
 	
-	namestr << hostname<<'/' << port->getInterface()->getOwner()->getName()
-		<< '/' << port->getName() << '/'<<this << '/' << getpid();
+	if (port->getInterface() && port->getInterface()->getOwner()) {
+	  namestr << hostname<<'/' << port->getInterface()->getOwner()->getName()
+		  << '/' << port->getName() << '/'<<this << '/' << getpid();
+	} else {
+	  namestr << hostname<<'/' << port->getName() << '/'<<this << '/' << getpid();
+	}
 	policy.name_id = namestr.str();
       }
       topicname=policy.name_id;
       Logger::In in(topicname);
-      log(Debug)<<"Creating ROS publisher for port "<<port->getInterface()->getOwner()->getName()<<"."<<port->getName()<<" on topic "<<policy.name_id<<endlog();
+
+      if (port->getInterface() && port->getInterface()->getOwner()) {
+        log(Debug)<<"Creating ROS publisher for port "<<port->getInterface()->getOwner()->getName()<<"."<<port->getName()<<" on topic "<<policy.name_id<<endlog();
+      } else {
+        log(Debug)<<"Creating ROS publisher for port "<<port->getName()<<" on topic "<<policy.name_id<<endlog();
+      }
 
       ros_pub = ros_node.advertise<T>(policy.name_id, policy.size ? policy.size : 1, policy.init); // minimum 1
       act = RosPublishActivity::Instance();
@@ -172,7 +181,11 @@ namespace ros_integration {
      */
     RosSubChannelElement(base::PortInterface* port, const ConnPolicy& policy)
     {
-      log(Debug)<<"Creating ROS subscriber for port "<<port->getInterface()->getOwner()->getName()<<"."<<port->getName()<<" on topic "<<policy.name_id<<endlog();
+      if (port->getInterface() && port->getInterface()->getOwner()) {
+        log(Debug)<<"Creating ROS subscriber for port "<<port->getInterface()->getOwner()->getName()<<"."<<port->getName()<<" on topic "<<policy.name_id<<endlog();
+      } else {
+        log(Debug)<<"Creating ROS subscriber for port "<<port->getName()<<" on topic "<<policy.name_id<<endlog();
+      }
       ros_sub=ros_node.subscribe(policy.name_id,policy.size,&RosSubChannelElement::newData,this);
       this->ref();
     }


### PR DESCRIPTION
Copied from http://bugs.orocos.org/show_bug.cgi?id=1000 :

I think the issues are still valid and I also would like to send a similar pull request to @jbohren's hydro-devel branch for the case they are accepted for master.

> Johannes Meyer 2012-10-24 17:14:06 CEST
> Created attachment 833 [details]
> fixed segfault when creating streams for  ports without a DataFlowInterface
> 
> I would like to contribute three patches for rtt_rosnode which basically enable generation of RTT typekits in other packages without a having to add a separate package. As bugzilla only allows to add one patch, I will add them as additional comments.
> 1. The first patch is more a bugfix as an enhancement, as the current version will segfault if used with ports that are not part of a TaskContext or DataFlowInterface, only because of logging port names.
> 
> Comment 1 Johannes Meyer 2012-10-24 17:16:16 CEST
> Created attachment 834 [details]
> moved implementation of  ros_publish_activity from header to source
> 
> This patches moves the implementation of the RosPublishActivity from the header to the source file. This allows including the header in other projects, e.g. to modify the priority of the publish activity.

(It also saves a few bytes in the transport libraries).

> Comment 2 Johannes Meyer 2012-10-24 17:19:07 CEST
> Created attachment 835 [details]
> moved set and add_definitions commands to  ros_generate_rtt_typekit
> 
> The GenerateRTTtypekit.cmake file modifies some cmake variables which are then valid for all subsequent targets added within the same project. Moving them to the ros_generate_rtt_typekit function does not change anything for typekits but does not affect other targets.
