### PR TITLE
rtt_rosparam: Added support for subservices

### DIFF
--- a/rtt_rosparam/README.md
+++ b/rtt_rosparam/README.md
@@ -29,16 +29,31 @@ policy (see below).
 
 #### Operations (getting/setting params)
 
-##### Operations on all properties
-* **getAll()** Attempt to get all properties from ros parameters in the
-  **COMPONENT** namespace.
-* **setAll()** Set ROS parameters in the **COMPONENT** namespace from all
-  properties of this component.
+##### Operations for getting all properties
+* **getAll()** or **getAllComponentPrivate()** Attempt to get all properties of this component (and its sub-services)
+  from the ROS parameter server in the **COMPONENT** namespace.
+* **getAllRelative()** Attempt to get all properties of this component (and its sub-services)
+  from the ROS parameter server in the relative namespace.
+* **getAllAbsolute()** Attempt to get all properties of this component (and its sub-services)
+  from the ROS parameter server in the absolute namespace.
+* **getAllPrivate()** Attempt to get all properties of this component (and its sub-services)
+  from the ROS parameter server in the node's private namespace.
+
+##### Operations for setting all properties
+* **setAll()** or **setAllComponentPrivate()** Stores all properties of this component (and its sub-services)
+  on the ROS parameter server from the similarly-named property in the **COMPONENT**'s private namespace.
+* **setAllRelative()** Stores all properties of this component (and its sub-services)
+  on the ROS parameter server from the similarly-named property in the relative namespace.
+* **setAllAbsolute()** Stores all properties of this component (and its sub-services)
+  on the ROS parameter server from the similarly-named property in the absolute namespace.
+* **setAllPrivate()** Stores all properties of this component (and its sub-services)
+  on the ROS parameter server from the similarly-named property in the node's private namespace.
+
 
 ##### Operations for getting single properties
 
-* **get(name,policy)** Attempt to get the property named **name** from the
-  namespace specified by **policy**.
+* **get(name,policy)** Attempt to get the property named **name** (or populates the properties of a named RTT sub-service)
+  from the ROS parameter namespace specified by **policy**.
 * **getRelative(name)**
 * **getAbsolute(name)**
 * **getPrivate(name)**
@@ -46,8 +61,8 @@ policy (see below).
 
 ##### Operations for setting single properties
 
-* **set(name,policy)** Attempt to set the property named **name** from the
-  namespace specified by **policy**.
+* **set(name,policy)** Attempt to set the property named **name** (or stores the properties of a named RTT sub-service)
+  in the ROS parameter namespace specified by **policy**.
 * **setRelative(name)**
 * **setAbsolute(name)**
 * **setPrivate(name)**
@@ -58,21 +73,21 @@ policy (see below).
 Components which were never meant to be used with ROS parameters can have their
 properties set from the ROS parameter server through the scripting interface:
 
-```cpp
+```
 // Import packages
-import("rtt_ros");
-ros.import("rtt_rosparam");
+import("rtt_ros")
+ros.import("rtt_rosparam")
 
 // Create your components ...
-laodService("my_component","rosparam");
+laodService("my_component","rosparam")
 
 // Try to get all parameters from the component namespace "~my_component/..."
-my_component.rosparam.getAll();
+my_component.rosparam.getAll()
 
 // Try to get the "robot_description" property from the absolute namespace "/robot_description"
-my_component.rosparam.getAbsolute("robot_description");
+my_component.rosparam.getAbsolute("robot_description")
 // Alternatively:
-my_component.rosparam.get("robot_description",my_component.rosparam.ABSOLUTE);
+my_component.rosparam.get("robot_description",my_component.rosparam.ABSOLUTE)
 ```
 
 ### C++ Interface
@@ -87,7 +102,7 @@ like the following:
 
 ```cpp
 // Include the service requester interface
-#include <rtt_rosparam/ROSParam.h>
+#include <rtt_rosparam/rosparam.h>
 
 
 class MyComponent : public RTT::TaskContext {

--- a/rtt_rosparam/src/rtt_rosparam_service.cpp
+++ b/rtt_rosparam/src/rtt_rosparam_service.cpp
@@ -29,62 +29,62 @@ public:
     this->addConstant("COMPONENT",COMPONENT);
 
     this->addOperation("getAllRelative", &ROSParamService::getParamsRelative, this)
-      .doc("Gets all properties of this component from the ROS param server in the relative namespace.");
+      .doc("Gets all properties of this component and its services from the ROS param server in the relative namespace.");
     this->addOperation("getAllAbsolute", &ROSParamService::getParamsAbsolute, this)
-      .doc("Gets all properties of this component from the ROS param server in the absolute namespace.");
+      .doc("Gets all properties of this component and its services from the ROS param server in the absolute namespace.");
     this->addOperation("getAllPrivate", &ROSParamService::getParamsPrivate, this)
-      .doc("Gets all properties of this component from the ROS param server in the node's private namespace.");
+      .doc("Gets all properties of this component and its services from the ROS param server in the node's private namespace.");
     this->addOperation("getAllComponentPrivate", &ROSParamService::getParamsComponentPrivate, this)
-      .doc("Gets all properties of this component from the ROS param server in the component's private namespace.");
+      .doc("Gets all properties of this component and its services from the ROS param server in the component's private namespace.");
     this->addOperation("getAll", &ROSParamService::getParamsComponentPrivate, this)
-      .doc("Gets all properties of this component from the ROS param server in the component's private namespace. This is just an alias for getAllComponentPrivate().");
+      .doc("Gets all properties of this component and its services from the ROS param server in the component's private namespace. This is just an alias for getAllComponentPrivate().");
 
     this->addOperation("setAllRelative", &ROSParamService::setParamsRelative, this)
-      .doc("Sets all properties of this component on the ROS param server from the similarly-named property of this component in the relative namespace.");
+      .doc("Sets all properties of this component on the ROS param server from the similarly-named property or service of this component in the relative namespace.");
     this->addOperation("setAllAbsolute", &ROSParamService::setParamsAbsolute, this)
-      .doc("Sets all properties of this component on the ROS param server from the similarly-named property of this component in the absolute namespace.");
+      .doc("Sets all properties of this component on the ROS param server from the similarly-named property or service of this component in the absolute namespace.");
     this->addOperation("setAllPrivate", &ROSParamService::setParamsPrivate, this)
-      .doc("Sets all properties of this component on the ROS param server from the similarly-named property of this component in the node's private namespace.");
+      .doc("Sets all properties of this component on the ROS param server from the similarly-named property or service of this component in the node's private namespace.");
     this->addOperation("setAllComponentPrivate", &ROSParamService::setParamsComponentPrivate, this)
-      .doc("Sets all properties of this component on the ROS param server from the similarly-named property of this component in the component's private namespace.");
+      .doc("Sets all properties of this component on the ROS param server from the similarly-named property or service of this component in the component's private namespace.");
     this->addOperation("setAll", &ROSParamService::setParamsComponentPrivate, this)
-      .doc("Sets all properties of this component on the ROS param server from the similarly-named property of this component in the component's private namespace. This is just an alias for setAll().");
+      .doc("Sets all properties of this component on the ROS param server from the similarly-named property or service of this component in the component's private namespace. This is just an alias for setAll().");
 
     this->addOperation("get", &ROSParamService::getParam, this) 
-      .doc("Gets one property of this component from the ROS param server based on the given resolution policy.")
+      .doc("Gets one property of this component from the ROS param server based on the given resolution policy or configures a service.")
       .arg("name", "Name of the property / parameter.")
       .arg("policy", "ROS parameter namespace resolution policy.");
 
     this->addOperation("getRelative", &ROSParamService::getParamRelative, this) 
-      .doc("Gets one property of this component from the ROS param server in the relative namespace.")
-      .arg("name", "Name of the property / parameter.");
+      .doc("Gets one property of this component from the ROS param server in the relative namespace or configures a service.")
+      .arg("name", "Name of the property / service / parameter.");
     this->addOperation("getAbsolute", &ROSParamService::getParamAbsolute, this) 
-      .doc("Gets one property of this component from the ROS param server in the absolute namespace.")
-      .arg("name", "Name of the property / parameter.");
+      .doc("Gets one property of this component from the ROS param server in the absolute namespace or configures a service.")
+      .arg("name", "Name of the property / service / parameter.");
     this->addOperation("getPrivate", &ROSParamService::getParamPrivate, this) 
-      .doc("Gets one property of this component from the ROS param server in the node's private namespace.")
-      .arg("name", "Name of the property / parameter.");
+      .doc("Gets one property of this component from the ROS param server in the node's private namespace or configures a service.")
+      .arg("name", "Name of the property / service / parameter.");
     this->addOperation("getComponentPrivate", &ROSParamService::getParamComponentPrivate, this) 
-      .doc("Gets one property of this component from the ROS param server in the component's private namespace.")
-      .arg("name", "Name of the property / parameter.");
+      .doc("Gets one property of this component from the ROS param server in the component's private namespace or configures a service.")
+      .arg("name", "Name of the property / service / parameter.");
 
     this->addOperation("set", &ROSParamService::setParam, this) 
-      .doc("Sets one parameter on the ROS param server from the similarly-named property of this component based on the given resolution policy.")
-      .arg("name", "Name of the property / parameter.")
+      .doc("Sets one parameter on the ROS param server from the similarly-named property or service of this component based on the given resolution policy.")
+      .arg("name", "Name of the property / service / parameter.")
       .arg("policy", "ROS parameter namespace resolution policy.");
 
     this->addOperation("setRelative", &ROSParamService::setParamRelative, this) 
-      .doc("Sets one parameter on the ROS param server from the similarly-named property of this component in the relative namespace.")
-      .arg("name", "Name of the property / parameter.");
+      .doc("Sets one parameter on the ROS param server from the similarly-named property or service of this component in the relative namespace.")
+      .arg("name", "Name of the property / service / parameter.");
     this->addOperation("setAbsolute", &ROSParamService::setParamAbsolute, this) 
-      .doc("Sets one parameter on the ROS param server from the similarly-named property of this component in the absolute namespace.")
-      .arg("name", "Name of the property / parameter.");
+      .doc("Sets one parameter on the ROS param server from the similarly-named property or service of this component in the absolute namespace.")
+      .arg("name", "Name of the property / service / parameter.");
     this->addOperation("setPrivate", &ROSParamService::setParamPrivate, this) 
-      .doc("Sets one parameter on the ROS param server from the similarly-named property of this component in the node's private namespace.")
-      .arg("name", "Name of the property / parameter.");
+      .doc("Sets one parameter on the ROS param server from the similarly-named property or service of this component in the node's private namespace.")
+      .arg("name", "Name of the property / service / parameter.");
     this->addOperation("setComponentPrivate", &ROSParamService::setParamComponentPrivate, this) 
-      .doc("Sets one parameter on the ROS param server from the similarly-named property of this component in the component's private namespace.")
-      .arg("name", "Name of the property / parameter.");
+      .doc("Sets one parameter on the ROS param server from the similarly-named property or service of this component in the component's private namespace.")
+      .arg("name", "Name of the property / service / parameter.");
   
   }
 private:

--- a/rtt_rosparam/src/rtt_rosparam_service.cpp
+++ b/rtt_rosparam/src/rtt_rosparam_service.cpp
@@ -29,61 +29,61 @@ public:
     this->addConstant("COMPONENT",COMPONENT);
 
     this->addOperation("getAllRelative", &ROSParamService::getParamsRelative, this)
-      .doc("Gets all properties of this component and its services from the ROS param server in the relative namespace.");
+      .doc("Gets all properties of this component (and its sub-services) from the ROS param server in the relative namespace.");
     this->addOperation("getAllAbsolute", &ROSParamService::getParamsAbsolute, this)
-      .doc("Gets all properties of this component and its services from the ROS param server in the absolute namespace.");
+      .doc("Gets all properties of this component (and its sub-services) from the ROS param server in the absolute namespace.");
     this->addOperation("getAllPrivate", &ROSParamService::getParamsPrivate, this)
-      .doc("Gets all properties of this component and its services from the ROS param server in the node's private namespace.");
+      .doc("Gets all properties of this component (and its sub-services) from the ROS param server in the node's private namespace.");
     this->addOperation("getAllComponentPrivate", &ROSParamService::getParamsComponentPrivate, this)
-      .doc("Gets all properties of this component and its services from the ROS param server in the component's private namespace.");
+      .doc("Gets all properties of this component (and its sub-services) from the ROS param server in the component's private namespace.");
     this->addOperation("getAll", &ROSParamService::getParamsComponentPrivate, this)
-      .doc("Gets all properties of this component and its services from the ROS param server in the component's private namespace. This is just an alias for getAllComponentPrivate().");
+      .doc("Gets all properties of this component (and its sub-services) from the ROS param server in the component's private namespace. This is an alias for getAllComponentPrivate().");
 
     this->addOperation("setAllRelative", &ROSParamService::setParamsRelative, this)
-      .doc("Sets all properties of this component on the ROS param server from the similarly-named property or service of this component in the relative namespace.");
+      .doc("Stores all properties of this component (and its sub-services) on the ROS param server from the similarly-named property in the relative namespace.");
     this->addOperation("setAllAbsolute", &ROSParamService::setParamsAbsolute, this)
-      .doc("Sets all properties of this component on the ROS param server from the similarly-named property or service of this component in the absolute namespace.");
+      .doc("Stores all properties of this component (and its sub-services) on the ROS param server from the similarly-named property in the absolute namespace.");
     this->addOperation("setAllPrivate", &ROSParamService::setParamsPrivate, this)
-      .doc("Sets all properties of this component on the ROS param server from the similarly-named property or service of this component in the node's private namespace.");
+      .doc("Stores all properties of this component (and its sub-services) on the ROS param server from the similarly-named property in the node's private namespace.");
     this->addOperation("setAllComponentPrivate", &ROSParamService::setParamsComponentPrivate, this)
-      .doc("Sets all properties of this component on the ROS param server from the similarly-named property or service of this component in the component's private namespace.");
+      .doc("Stores all properties of this component (and its sub-services) on the ROS param server from the similarly-named property in the component's private namespace.");
     this->addOperation("setAll", &ROSParamService::setParamsComponentPrivate, this)
-      .doc("Sets all properties of this component on the ROS param server from the similarly-named property or service of this component in the component's private namespace. This is just an alias for setAll().");
+      .doc("Stores all properties of this component (and its sub-services) on the ROS param server from the similarly-named property in the component's private namespace. This is an alias for setAllComponentPrivate().");
 
     this->addOperation("get", &ROSParamService::getParam, this) 
-      .doc("Gets one property of this component from the ROS param server based on the given resolution policy or configures a service.")
-      .arg("name", "Name of the property / parameter.")
+      .doc("Gets one property of this component (or populates the properties of a named RTT sub-service) from the ROS param server based on the given resolution policy.")
+      .arg("name", "Name of the property / service / parameter.")
       .arg("policy", "ROS parameter namespace resolution policy.");
 
     this->addOperation("getRelative", &ROSParamService::getParamRelative, this) 
-      .doc("Gets one property of this component from the ROS param server in the relative namespace or configures a service.")
+      .doc("Gets one property of this component (or populates the properties of a named RTT sub-service) from the ROS param server in the relative namespace.")
       .arg("name", "Name of the property / service / parameter.");
     this->addOperation("getAbsolute", &ROSParamService::getParamAbsolute, this) 
-      .doc("Gets one property of this component from the ROS param server in the absolute namespace or configures a service.")
+      .doc("Gets one property of this component (or populates the properties of a named RTT sub-service) from the ROS param server in the absolute namespace.")
       .arg("name", "Name of the property / service / parameter.");
     this->addOperation("getPrivate", &ROSParamService::getParamPrivate, this) 
-      .doc("Gets one property of this component from the ROS param server in the node's private namespace or configures a service.")
+      .doc("Gets one property of this component (or populates the properties of a named RTT sub-service) from the ROS param server in the node's private namespace.")
       .arg("name", "Name of the property / service / parameter.");
     this->addOperation("getComponentPrivate", &ROSParamService::getParamComponentPrivate, this) 
-      .doc("Gets one property of this component from the ROS param server in the component's private namespace or configures a service.")
+      .doc("Gets one property of this component (or populates the properties of a named RTT sub-service) from the ROS param server in the component's private namespace.")
       .arg("name", "Name of the property / service / parameter.");
 
     this->addOperation("set", &ROSParamService::setParam, this) 
-      .doc("Sets one parameter on the ROS param server from the similarly-named property or service of this component based on the given resolution policy.")
+      .doc("Sets one parameter on the ROS param server from the similarly-named property of this component (or stores the properties of a named RTT sub-service) in the ROS parameter namespace based on the given resolution policy.")
       .arg("name", "Name of the property / service / parameter.")
       .arg("policy", "ROS parameter namespace resolution policy.");
 
     this->addOperation("setRelative", &ROSParamService::setParamRelative, this) 
-      .doc("Sets one parameter on the ROS param server from the similarly-named property or service of this component in the relative namespace.")
+      .doc("Sets one parameter on the ROS param server from the similarly-named property of this component (or stores the properties of a named RTT sub-service) in the relative namespace.")
       .arg("name", "Name of the property / service / parameter.");
     this->addOperation("setAbsolute", &ROSParamService::setParamAbsolute, this) 
-      .doc("Sets one parameter on the ROS param server from the similarly-named property or service of this component in the absolute namespace.")
+      .doc("Sets one parameter on the ROS param server from the similarly-named property of this component (or stores the properties of a named RTT sub-service) in the absolute namespace.")
       .arg("name", "Name of the property / service / parameter.");
     this->addOperation("setPrivate", &ROSParamService::setParamPrivate, this) 
-      .doc("Sets one parameter on the ROS param server from the similarly-named property or service of this component in the node's private namespace.")
+      .doc("Sets one parameter on the ROS param server from the similarly-named property of this component (or stores the properties of a named RTT sub-service) in the node's private namespace.")
       .arg("name", "Name of the property / service / parameter.");
     this->addOperation("setComponentPrivate", &ROSParamService::setParamComponentPrivate, this) 
-      .doc("Sets one parameter on the ROS param server from the similarly-named property or service of this component in the component's private namespace.")
+      .doc("Sets one parameter on the ROS param server from the similarly-named property of this component (or stores the properties of a named RTT sub-service) in the component's private namespace.")
       .arg("name", "Name of the property / service / parameter.");
   
   }

--- a/rtt_rosparam/src/rtt_rosparam_service.cpp
+++ b/rtt_rosparam/src/rtt_rosparam_service.cpp
@@ -506,7 +506,9 @@ bool ROSParamService::getParams(RTT::Service::shared_ptr service, const std::str
   {
     RTT::Service::shared_ptr sub(service->getService(*it));
     if (sub) {
-      if (!getParams(sub, ns + "/" + sub->getName(), policy)) return false;
+      std::string sub_ns = sub->getName();
+      if (!ns.empty()) sub_ns = ns + "/" + sub_ns;
+      getParams(sub, sub_ns, policy);
     }
   }
 


### PR DESCRIPTION
Moved from https://github.com/jhu-lcsr-forks/rtt_ros_integration/pull/50 (with one additional patch):

This patch will add sub-service support to rtt_rosparam. A component could have nested services that also have properties. Currently it is not possible to load or store parameters of nested services.

There are several modifications, that I shortly summarize here:
1. I added policy-specific operations `getAllXXX()` and `setAllXXX()` in analogy to the per-parameter operations. This is not directly related to services, but I need it to fetch all parameters of a component with a nested service from another namespace than it's private component namespace (dd2ef57).
2. The `getAllXXX()` and `setAllXXX()` operations will recurse into services and also get/set their properties from/on the parameter server. This will only work for services, not for peers.
3. If a service is passed to `getXXX(name)` or `setXXX(name)` operations and no property of that name exists, the rosparam service will search a service with that name and recursively call `getAllXXX()`/`setAllXXX()` for that specific service only.

Note that `getAllAbsolute()` and `setAllAbsolute()` (where the latter probably does not make so much sense anyway) currently are broken due to https://github.com/ros/ros_comm/pull/313.
