### PR TITLE
Collect all global ROS operations in service ros

### DIFF
--- a/rtt_ros/src/rtt_ros_service.cpp
+++ b/rtt_ros/src/rtt_ros_service.cpp
@@ -12,15 +12,10 @@
 #include <libxml/tree.h>
 
 #include <rtt/RTT.hpp>
-#include <rtt/plugin/ServicePlugin.hpp>
 #include <rtt/internal/GlobalService.hpp>
 
 #include <rtt/deployment/ComponentLoader.hpp>
-#include <rtt/TaskContext.hpp>
 #include <rtt/Logger.hpp>
-#include <rtt/os/StartStopManager.hpp>
-#include <rtt/plugin/PluginLoader.hpp>
-#include <rtt/types/TypekitRepository.hpp>
 
 #include <rospack/rospack.h>
 
@@ -32,32 +27,13 @@ using namespace std;
 /**
  * The globally loadable ROS service.
  */
-class ROSService : public RTT::Service {
+class ROSService {
 public:
-  int protocol_id;
-  /**
-   * Instantiates this service.
-   * @param owner The owner or null in case of global.
-   */
-  ROSService(TaskContext* owner) 
-    : Service("ros", owner)
-  {
-    this->doc("RTT service for loading RTT plugins ");
-
-    // ROS Package-importing
-    this->addOperation("import", &ROSService::import, this).doc(
-        "Imports the Orocos plugins from a given ROS package (if found) along with the plugins of all of the package's run or exec dependencies as listed in the package.xml.").arg(
-            "package", "The ROS package name.");
-
-    this->provides("time")->addOperation("now", &rtt_ros::time::now).doc(
-        "Get a ros::Time structure based on the RTT time source.");
-  }
-
   /**
    * Returns a ConnPolicy object for streaming to or from 
    * the given ROS topic. No buffering is done.
    */
-  bool import(const std::string& package) 
+  static bool import(const std::string& package)
   {
     RTT::Logger::In in("ROSService::import(\""+package+"\")");
 
@@ -235,13 +211,23 @@ public:
 };
 
 void loadROSService(){
-  RTT::Service::shared_ptr rts(new ROSService(0));
-  RTT::internal::GlobalService::Instance()->addService(rts);
+  RTT::Service::shared_ptr ros = RTT::internal::GlobalService::Instance()->provides("ros");
+
+  ros->doc("RTT service for loading RTT plugins ");
+
+  // ROS Package-importing
+  ros->addOperation("import", &ROSService::import).doc(
+      "Imports the Orocos plugins from a given ROS package (if found) along with the plugins of all of the package's run or exec dependencies as listed in the package.xml.").arg(
+          "package", "The ROS package name.");
+
+  ros->provides("time")->addOperation("now", &rtt_ros::time::now).doc(
+      "Get a ros::Time structure based on the RTT time source.");
 }
 
 using namespace RTT;
 extern "C" {
   bool loadRTTPlugin(RTT::TaskContext* c){
+    if (c != 0) return false;
     loadROSService();
     return true;
   }

--- a/rtt_roscomm/include/rtt_rostopic/rostopic.h
+++ b/rtt_roscomm/include/rtt_rostopic/rostopic.h
@@ -11,18 +11,18 @@ namespace rtt_rostopic {
   class ROSTopic : public RTT::ServiceRequester
   {
   public:
-    ROSTopic() :
-      RTT::ServiceRequester("rostopic",NULL),
-      connection("connection"),
-      bufferedConnection("bufferedConnection"),
-      unbufferedConnection("unbufferedConnection"),
+    ROSTopic(RTT::TaskContext *owner = 0) :
+      RTT::ServiceRequester("rostopic", owner),
+      connection("topic"),
+      bufferedConnection("topicBuffer"),
+      unbufferedConnection("topicUnbuffered"),
       protocol_id(ORO_ROS_PROTOCOL_ID)
     {
       this->addOperationCaller(connection);
       this->addOperationCaller(bufferedConnection);
       this->addOperationCaller(unbufferedConnection);
 
-      this->connectTo(RTT::internal::GlobalService::Instance()->provides("rostopic"));
+      this->connectTo(RTT::internal::GlobalService::Instance()->provides("ros"));
     }
 
     RTT::OperationCaller<RTT::ConnPolicy(const std::string &)> connection;

--- a/rtt_roscomm/src/rtt_rosservice_registry_service.cpp
+++ b/rtt_roscomm/src/rtt_rosservice_registry_service.cpp
@@ -103,6 +103,7 @@ void loadROSServiceRegistryService()
 using namespace RTT;
 extern "C" {
   bool loadRTTPlugin(RTT::TaskContext* c){
+    if (c != 0) return false;
     loadROSServiceRegistryService();
     return true;
   }

--- a/rtt_roscomm/src/rtt_rostopic_service.cpp
+++ b/rtt_roscomm/src/rtt_rostopic_service.cpp
@@ -1,5 +1,4 @@
 #include <rtt/RTT.hpp>
-#include <rtt/plugin/ServicePlugin.hpp>
 #include <rtt/internal/GlobalService.hpp>
 #include <rtt_rostopic/rtt_rostopic.h> 
 
@@ -9,43 +8,17 @@ using namespace std;
 /**
  * The globally loadable ROS service.
  */
-class ROSTopicService : public RTT::Service {
+class ROSTopicService {
 public:
-  int protocol_id;
-  /**
-   * Instantiates this service.
-   * @param owner The owner or null in case of global.
-   */
-  ROSTopicService(TaskContext* owner) 
-    : Service("rostopic", owner),
-    protocol_id(ORO_ROS_PROTOCOL_ID)
-  {
-    this->doc("Main RTT Service for connecting RTT ports to ROS message topics. See also the 'rosparam' service which can be added to a component and the 'rospack' global service for finding ros packages.");
-
-    // ROS Package-importing
-
-    // ROS Topic-based Operations
-    this->addOperation("connection", &ROSTopicService::topic, this).doc(
-        "Creates a ConnPolicy for subscribing to or publishing a topic. No buffering is done, only the last message is kept.").arg(
-            "name", "The ros topic name");
-    this->addOperation("bufferedConnection", &ROSTopicService::topicBuffer, this).doc(
-        "Creates a ConnPolicy for subscribing to or publishing a topic with a fixed-length message buffer.").arg(
-            "name", "The ros topic name").arg(
-            "size","The size of the buffer.");
-    this->addOperation("unbufferedConnection", &ROSTopicService::topicUnbuffered, this).doc(
-        "Creates a ConnPolicy for unbuffered publishing a topic. This may not be real-time safe!").arg(
-            "name", "The ros topic name");
-    this->addConstant("protocol_id", protocol_id );
-
-  }
+  static const int protocol_id;
 
   /**
    * Returns a ConnPolicy object for streaming to or from 
    * the given ROS topic. No buffering is done.
    */
-  ConnPolicy topic(const std::string& name) {
+  static ConnPolicy topic(const std::string& name) {
     ConnPolicy cp = ConnPolicy::data();
-    cp.transport = ORO_ROS_PROTOCOL_ID;
+    cp.transport = protocol_id;
     cp.name_id = name;
     return cp;
   }
@@ -55,9 +28,9 @@ public:
    * the given ROS topic. Also specifies the buffer size of
    * the connection to be created.
    */
-  ConnPolicy topicBuffer(const std::string& name, int size) {
+  static ConnPolicy topicBuffer(const std::string& name, int size) {
     ConnPolicy cp = ConnPolicy::buffer(size);
-    cp.transport = ORO_ROS_PROTOCOL_ID;
+    cp.transport = protocol_id;
     cp.name_id = name;
     return cp;
   }
@@ -68,22 +41,37 @@ public:
    * publishing, where the publish() method is called
    * in the thread of the writing TaskContext.
    */
-  ConnPolicy topicUnbuffered(const std::string& name) {
+  static ConnPolicy topicUnbuffered(const std::string& name) {
     ConnPolicy cp = ConnPolicy();
     cp.type = ConnPolicy::UNBUFFERED;
-    cp.transport = ORO_ROS_PROTOCOL_ID;
+    cp.transport = protocol_id;
     cp.name_id = name;
     return cp;
   }};
 
+const int ROSTopicService::protocol_id = ORO_ROS_PROTOCOL_ID;
+
 void loadROSTopicService(){
-  RTT::Service::shared_ptr rts(new ROSTopicService(0));
-  RTT::internal::GlobalService::Instance()->addService(rts);
+  RTT::Service::shared_ptr ros = RTT::internal::GlobalService::Instance()->provides("ros");
+
+  // ROS Topic-based Operations
+  ros->addOperation("topic", &ROSTopicService::topic).doc(
+      "Creates a ConnPolicy for subscribing to or publishing a topic. No buffering is done, only the last message is kept.").arg(
+          "name", "The ros topic name");
+  ros->addOperation("topicBuffer", &ROSTopicService::topicBuffer).doc(
+      "Creates a ConnPolicy for subscribing to or publishing a topic with a fixed-length message buffer.").arg(
+          "name", "The ros topic name").arg(
+          "size","The size of the buffer.");
+  ros->addOperation("topicUnbuffered", &ROSTopicService::topicUnbuffered).doc(
+      "Creates a ConnPolicy for unbuffered publishing a topic. This may not be real-time safe!").arg(
+          "name", "The ros topic name");
+  ros->addConstant("protocol_id", ROSTopicService::protocol_id);
 }
 
 using namespace RTT;
 extern "C" {
   bool loadRTTPlugin(RTT::TaskContext* c){
+    if (c != 0) return false;
     loadROSTopicService();
     return true;
   }

--- a/rtt_rospack/src/rtt_rospack_service.cpp
+++ b/rtt_rospack/src/rtt_rospack_service.cpp
@@ -56,6 +56,7 @@ void loadROSPackService(){
 using namespace RTT;
 extern "C" {
   bool loadRTTPlugin(RTT::TaskContext* c){
+    if (c != 0) return false;
     loadROSPackService();
     return true;
   }

--- a/tests/rtt_roscomm_tests/test/api_tests.cpp
+++ b/tests/rtt_roscomm_tests/test/api_tests.cpp
@@ -35,7 +35,7 @@ TEST(BasicTest, ImportTypekit)
 {
   // Import rtt_ros plugin
   EXPECT_TRUE(RTT::ComponentLoader::Instance()->import("rtt_std_msgs", "" ));
-  EXPECT_TRUE(scripting_service->eval("var ConnPolicy float_out = rostopic.connection(\"float_out\")"));
+  EXPECT_TRUE(scripting_service->eval("var ConnPolicy float_out = ros.topic(\"float_out\")"));
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
The hydro-devel branch introduced the new `rostopic` global service that provides operations to create ROS streaming ConnPolicies. I would prefer to use the global service `ros` instead to collect all kind of ROS-related operations that not require to be loaded in a specific component. With this patch the rostopic plugin only installs operations in the global service "ros" instead of adding a new global service. The packages can (and must) still be imported independently:

```
import("rtt_ros") # installs global service "ros" and the ros.import() operation
ros.import("rtt_std_msgs") # imports rtt_roscomm package from rtt_std_msgs's <plugin_depend>
                           # and adds operations ros.topic, ros.topicBuffer and ros.topicUnbuffered

stream("foo.bar", ros.topic("bar"))
...
```

The main driver for this proposal is backwards compatibility with scripts generated for older versions of the toolchain. And I personally liked the `ros.topic(...)` syntax more than `rostopic.connection(...)`.

The ServiceRequester `rtt_rostopic::ROSTopic` would still work and uses the new names for the OperationCallers.

Just a suggestion. What do you think?
