### PR TITLE
rtt_dynamic_reconfigure

### DIFF
--- a/rtt_rosnode/src/ros_plugin.cpp
+++ b/rtt_rosnode/src/ros_plugin.cpp
@@ -55,12 +55,16 @@ extern "C" {
       }
     }
 
+    // get number of spinners from parameter server, if available
+    int thread_count = 1;
+    ros::param::get("~spinner_threads", thread_count);
+
     // Create an asynchronous spinner to handle the default callback queue 
-    static ros::AsyncSpinner spinner(1); // Use 1 threads
+    static ros::AsyncSpinner spinner(thread_count); // Use thread_count threads
 
     // TODO: Check spinner.canStart() to suppress errors / warnings once it's incorporated into ROS
     spinner.start();
-    log(Info)<<"ROS node spinner started."<<endlog();
+    log(Info)<<"ROS node spinner started (" << thread_count << " " << (thread_count > 1 ? "threads" : "thread") << ")."<<endlog();
 
     return true;
   }

--- a/rtt_tf/rtt_tf-component.cpp
+++ b/rtt_tf/rtt_tf-component.cpp
@@ -134,6 +134,9 @@ namespace rtt_tf
           StampedTransform trans;
           transformStampedMsgToTF(msg_in.transforms[i], trans);
           try {
+#if ROS_VERSION_MINIMUM(1,11,0)
+            this->setTransform(trans);
+#else
             std::map<std::string, std::string>* msg_header_map =
               msg_in.__connection_header.get();
             std::string authority;
@@ -147,6 +150,7 @@ namespace rtt_tf
               authority = it->second;
             }
             this->setTransform(trans, authority);
+#endif
           } catch (TransformException& ex) {
             log(Error) << "Failure to set received transform from "
               << msg_in.transforms[i].child_frame_id << " to "


### PR DESCRIPTION
This pull request adds the rtt_dynamic_reconfigure package.

It provides a RTT service that implements a [dynamic_reconfigure](http://wiki.ros.org/dynamic_reconfigure) server to configure the owning TaskContext. There are two possible usages:
- Write a component-specific [dynamic_reconfigure config file](http://wiki.ros.org/dynamic_reconfigure/Tutorials/HowToWriteYourFirstCfgFile) with the same parameter names than the properties that should be configured. Descriptions, minimum and maximum values are taken from the config file. A special service plugin can simply be created with the `RTT_DYNAMIC_RECONFIGURE_SERVICE_PLUGIN` macro:
  
  ``` cpp
  #include <rtt_dynamic_reconfigure/server.h>
  #include <my_package/MyConfig.h>  // generated by dynamic_reconfigure
  
  using namespace my_package;
  
  template<>
  struct rtt_dynamic_reconfigure::Updater<MyConfig> {
      static bool propertiesFromConfig(MyConfig &config, uint32_t level, RTT::PropertyBag &target)
      {
          // ...
      }
  
      static bool configFromProperties(MyConfig &config, const RTT::PropertyBag &source)
      {
          // ...
      }
  };
  
  RTT_DYNAMIC_RECONFIGURE_SERVICE_PLUGIN(MyConfig, "reconfigure")
  ```
  
  Properties that exist in the config file but not in the component can be created automatically depending on the implementation of `propertiesFromConfig()`.
  
  See [rtt_dynamic_reconfigure_tests](https://github.com/meyerj/rtt_ros_integration/blob/rtt_dynamic_reconfigure/tests/rtt_dynamic_reconfigure_tests) for a simple example.
- Use the special `AutoConfig` type. `rtt_dynamic_reconfigure` already provides a `reconfigure` service itself, that tries to convert the existing properties in a dynamic_reconfigure config description. Minimum, maximum and default values can be set in the `reconfigure.min`, `reconfigure.max` and `reconfigure.default` property bags.
  
  The supported property types are limited.

Open issues:
- [x] Add documentation
- [x] Make parameter/property updates real-time safe
- [x] Fully support description updates after having added properties or updated the meta information
