### PR TITLE
Numerous fixes to rtt_tf's tf_interface, also filling out rtt_rosparam's service requester

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,16 @@ The packages in this repository provide:
 * [**rtt\_roscomm**](rtt_roscomm) ROS message typekit generation and Orocos
   plugin for publishing and subscribing to ROS topics as well as calling and
   responding to ROS services.
+* [**rtt\_rosdeployment**](rtt_rosdeployment) An RTT service which advertises
+  common DeploymentComponent operations as ROS services.
 * [**rtt\_rospack**](rtt_rospack) Plugin for locating ROS resources.
 * [**rtt\_tf**](rtt_tf) RTT-Plugin which uses [tf](http://ros.org/wiki/tf) to
   allow RTT components to lookup and publish transforms.
 * [**rtt\_actionlib**](rtt_actionlib) RTT-Enabled
   [actionlib](http://ros.org/wiki/actionlib) action server for providing
   actions from ROS-integrated RTT components.
+* [**rtt\_ros\_msgs**](rtt_ros_msgs) ROS .msg and .srv types for use with these
+  plugins.
 * [**rtt\_ros\_integration**](rtt_ros_integration) Catkin
   [metapackage](http://ros.org/wiki/catkin/package.xml#Metapackages) for this
   repository.
@@ -326,8 +330,6 @@ RTT components. See [rtt_actionlib](rtt_actionlib) for more information.
 The following packages are in the planning stages, please contact the
 maintainers if you're interested in using or contributing to them:
 
-* [**rtt\_rosops**](rtt_rosops) Plugin for executing Orocos Ops script via ROS
-  service call.
 * [**rtt\_dynamic_reconfigure**](rtt_dynamic_reconfigure) Plugin for running
   a [dynamic\_reconfigure](http://ros.org/wiki/dynamic_reconfigure) server from
   an RTT component.

--- a/rtt_actionlib/include/rtt_actionlib/rtt_action_server.h
+++ b/rtt_actionlib/include/rtt_actionlib/rtt_action_server.h
@@ -214,7 +214,7 @@ namespace rtt_actionlib {
 
       // Create the action result container
       ActionResult action_result;
-      action_result.header.stamp = rtt_rosclock::host_rt_now();
+      action_result.header.stamp = rtt_rosclock::host_now();
       action_result.status = status;
       action_result.result = result;
 
@@ -237,7 +237,7 @@ namespace rtt_actionlib {
 
       // Create the action result container
       ActionFeedback action_feedback;
-      action_feedback.header.stamp = rtt_rosclock::host_rt_now();
+      action_feedback.header.stamp = rtt_rosclock::host_now();
       action_feedback.status = status;
       action_feedback.feedback = feedback;
 
@@ -255,7 +255,7 @@ namespace rtt_actionlib {
       // Build a status array
       actionlib_msgs::GoalStatusArray status_array;
 
-      status_array.header.stamp = rtt_rosclock::host_rt_now();
+      status_array.header.stamp = rtt_rosclock::host_now();
 
       status_array.status_list.resize(this->status_list_.size());
 
@@ -268,7 +268,7 @@ namespace rtt_actionlib {
 
         // Check if the item is due for deletion from the status list
         if((*it).handle_destruction_time_ != ros::Time() &&
-           (*it).handle_destruction_time_ + this->status_list_timeout_ < rtt_rosclock::host_rt_now()){
+           (*it).handle_destruction_time_ + this->status_list_timeout_ < rtt_rosclock::host_now()){
           it = this->status_list_.erase(it);
         } else {
           ++it;

--- a/rtt_ros_msgs/CMakeLists.txt
+++ b/rtt_ros_msgs/CMakeLists.txt
@@ -1,0 +1,60 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(rtt_ros_msgs)
+
+find_package(catkin REQUIRED COMPONENTS message_generation std_msgs) 
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## To declare and build messages, services or actions from within this
+## package, follow these steps:
+## * Let MSG_DEP_SET be the set of packages whose message types you use in
+##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
+## * In the file package.xml:
+##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
+##   * If MSG_DEP_SET isn't empty the following dependencies might have been
+##     pulled in transitively but can be declared for certainty nonetheless:
+##     * add a build_depend tag for "message_generation"
+##     * add a run_depend tag for "message_runtime"
+## * In this file (CMakeLists.txt):
+##   * add "message_generation" and every package in MSG_DEP_SET to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * add "message_runtime" and every package in MSG_DEP_SET to
+##     catkin_package(CATKIN_DEPENDS ...)
+##   * uncomment the add_*_files sections below as needed
+##     and list every .msg/.srv/.action file to be processed
+##   * uncomment the generate_messages entry below
+##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+add_service_files(
+  FILES
+  RunScript.srv
+  GetPeerList.srv
+  )
+
+## Generate actions in the 'action' folder
+# add_action_files(
+#   FILES
+#   Action1.action
+#   Action2.action
+# )
+
+## Generate added messages and services with any dependencies listed here
+generate_messages(
+  DEPENDENCIES
+  std_msgs  
+)
+
+catkin_package(
+  CATKIN_DEPENDS message_runtime
+)
+

--- a/rtt_ros_msgs/package.xml
+++ b/rtt_ros_msgs/package.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package>
+  <name>rtt_ros_msgs</name>
+  <version>2.7.0</version>
+  <description>This package provides .msg and .srv files for use with the rtt_ros_integration packages.</description>
+
+  <maintainer email="jbo@jhu.edu">Jonathan Bohren</maintainer>
+
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>std_msgs</build_depend>
+  <build_depend>message_generation</build_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>message_runtime</run_depend>
+</package>

--- a/rtt_ros_msgs/srv/GetPeerList.srv
+++ b/rtt_ros_msgs/srv/GetPeerList.srv
@@ -1,0 +1,2 @@
+---
+string[] peers

--- a/rtt_ros_msgs/srv/RunScript.srv
+++ b/rtt_ros_msgs/srv/RunScript.srv
@@ -1,0 +1,3 @@
+string file_path
+---
+bool success

--- a/rtt_rosclock/include/rtt_rosclock/rtt_rosclock.h
+++ b/rtt_rosclock/include/rtt_rosclock/rtt_rosclock.h
@@ -7,17 +7,47 @@
 
 namespace rtt_rosclock {
 
-  //! Get the current time according to RTT
+  /** \brief Get the current time according to CLOCK_HOST_REALTIME or the
+   * simulation time.
+   *
+   * This is the time source that should always be used with ROS header
+   * timestamps because it is the time that you want to use to broadcast ROS
+   * messages to other machines or processes. 
+   *
+   * When compiled against Xenomai and not running in simulation mode,
+   * this function will return the NTP-synchronized clock time via the
+   * CLOCK_HOST_REALTIME clock source. Note that this is only supported under
+   * Xenomai 2.6 and above.
+   *
+   * When not compiled against Xenomai and not running in simulation mode, it
+   * is a pass-through to ros::Time::now().
+   *
+   * When running in simulation mode, this will always use the simulation
+   * clock, which is based off of the ROS /clock topic. It is a pass-through to
+   * rtt_now().
+   */
+  const ros::Time host_now();
+
+  /** \brief Get the current time according to CLOCK_HOST_REALTIME or the
+   * wall time.
+   */
+  const ros::Time host_wall_now();
+
+  /** \brief Get the current time according to RTT
+   *
+   * If the simulation clock is enabled, this will return the simulated time.
+   */
   const ros::Time rtt_now();
+  
+  /** \brief Get the current wall time according to RTT
+   *
+   * Even if the simualtion clock is enabled, this will still return the wall
+   * clock time.
+   */
+  const ros::Time rtt_wall_now();
 
-  //! Get the current time according to ROS
-  const ros::Time ros_now();
-
-  //! Get the current time according to CLOCK_HOST_REALTIME
-  const ros::Time host_rt_now();
-
-  //! Get the difference in seconds between RTT and CLOCK_HOST_REALTIME
-  const RTT::Seconds host_rt_offset_from_rtt();
+  //! Get the difference in seconds between rtt_wall_now() and host_wall_now()
+  const RTT::Seconds host_offset_from_rtt();
 
   //! Set a TaskContext to use a periodic simulation clock activity
   const bool set_sim_clock_activity(RTT::TaskContext *t);

--- a/rtt_rosclock/src/rtt_rosclock.cpp
+++ b/rtt_rosclock/src/rtt_rosclock.cpp
@@ -51,10 +51,12 @@ const ros::Time rtt_rosclock::host_wall_now()
 
 const ros::Time rtt_rosclock::rtt_now() 
 {
+  // count the zeros...   -987654321--
+  const uint64_t one_E9 = 1000000000ll;
   // NOTE: getNSecs returns wall time, getTicks returns offset time
   uint64_t nsec64 = RTT::os::TimeService::ticks2nsecs(RTT::os::TimeService::Instance()->getTicks()); //RTT::os::TimeService::Instance()->getNSecs();
-  uint32_t sec = nsec64 / 1E9;
-  uint32_t nsec = (uint32_t)(nsec64 - (sec*1E9));
+  uint32_t sec = nsec64 / one_E9;
+  uint32_t nsec = (uint32_t)(nsec64 - (sec*one_E9));
   return ros::Time(sec, nsec);
 }
 

--- a/rtt_rosclock/src/rtt_rosclock.cpp
+++ b/rtt_rosclock/src/rtt_rosclock.cpp
@@ -10,44 +10,66 @@ namespace rtt_rosclock {
   boost::shared_ptr<rtt_rosclock::SimClockThread> sim_clock_thread;
 }
 
+const ros::Time rtt_rosclock::host_now()
+{
+  if(SimClockThread::GetInstance() && SimClockThread::GetInstance()->simTimeEnabled()) {
+    return rtt_now();   
+  }
+
+  #ifdef __XENO__
+    // Use Xenomai 2.6 feature to get the NTP-synched real-time clock
+    timespec ts = {0,0};
+    int ret = clock_gettime(CLOCK_HOST_REALTIME, &ts);
+    if(ret) {
+      RTT::log(RTT::Error) << "Could not query CLOCK_HOST_REALTIME (" << CLOCK_HOST_REALTIME <<"): "<< errno << RTT::endlog();
+      return rtt_rosclock::rtt_now();
+    }
+
+    return ros::Time(ts.tv_sec, ts.tv_nsec);
+  #else 
+    return ros::Time::now();
+  #endif
+}
+
+const ros::Time rtt_rosclock::host_wall_now() 
+{
+  #ifdef __XENO__
+    // Use Xenomai 2.6 feature to get the NTP-synched real-time clock
+    timespec ts = {0,0};
+    int ret = clock_gettime(CLOCK_HOST_REALTIME, &ts);
+    if(ret) {
+      RTT::log(RTT::Error) << "Could not query CLOCK_HOST_REALTIME (" << CLOCK_HOST_REALTIME <<"): "<< errno << RTT::endlog();
+      return rtt_rosclock::rtt_wall_now();
+    }
+
+    return ros::Time(ts.tv_sec, ts.tv_nsec);
+  #else 
+    ros::WallTime now(ros::WallTime::now());
+    return ros::Time(now.sec, now.nsec);
+  #endif
+}
+
 const ros::Time rtt_rosclock::rtt_now() 
 {
-  //return ros::Time(((double)RTT::os::TimeService::ticks2nsecs(RTT::os::TimeService::Instance()->getTicks()))*1E-9);
+  // NOTE: getNSecs returns wall time, getTicks returns offset time
   uint64_t nsec64 = RTT::os::TimeService::ticks2nsecs(RTT::os::TimeService::Instance()->getTicks()); //RTT::os::TimeService::Instance()->getNSecs();
   uint32_t sec = nsec64 / 1E9;
   uint32_t nsec = (uint32_t)(nsec64 - (sec*1E9));
   return ros::Time(sec, nsec);
 }
 
-const ros::Time rtt_rosclock::ros_now() 
+const ros::Time rtt_rosclock::rtt_wall_now()
 {
-  return ros::Time::now();
+  // NOTE: getNSecs returns wall time, getTicks returns offset time
+  uint64_t nsec64 = RTT::os::TimeService::Instance()->getNSecs();
+  uint32_t sec = nsec64 / 1E9;
+  uint32_t nsec = (uint32_t)(nsec64 - (sec*1E9));
+  return ros::Time(sec, nsec);
 }
 
-const ros::Time rtt_rosclock::host_rt_now() 
+const RTT::Seconds rtt_rosclock::host_offset_from_rtt() 
 {
-  if(SimClockThread::GetInstance() && SimClockThread::GetInstance()->simTimeEnabled()) {
-    return rtt_now();   
-  } else {
-    #ifdef __XENO__
-    // Use Xenomai 2.6 feature to get the NTP-synched real-time clock
-    timespec ts = {0,0};
-    int ret = clock_gettime(CLOCK_HOST_REALTIME, &ts);
-    if(ret) {
-      RTT::log(RTT::Error) << "Could not query CLOCK_HOST_REALTIME (" << CLOCK_HOST_REALTIME <<"): "<< errno << RTT::endlog();
-    }
-
-    return ros::Time(ts.tv_sec, ts.tv_nsec);
-    #else 
-    ros::WallTime now(ros::WallTime::now());
-    return ros::Time(now.sec, now.nsec);
-    #endif
-  }
-}
-
-const RTT::Seconds rtt_rosclock::host_rt_offset_from_rtt() 
-{
-  return (rtt_rosclock::host_rt_now() - rtt_rosclock::rtt_now()).toSec();
+  return (rtt_rosclock::host_wall_now() - rtt_rosclock::rtt_wall_now()).toSec();
 }
 
 void rtt_rosclock::use_ros_clock_topic()

--- a/rtt_rosclock/src/rtt_rosclock_service.cpp
+++ b/rtt_rosclock/src/rtt_rosclock_service.cpp
@@ -17,16 +17,18 @@ void loadROSClockService(){
   sim_clock_thread = rtt_rosclock::SimClockThread::Instance();
 
   // Getting current time 
+  rosclock->addOperation("host_now", &rtt_rosclock::host_now).doc(
+      "Get a ros::Time structure based on the NTP-corrected RT time or the ROS simulation time.");
+  rosclock->addOperation("host_wall_now", &rtt_rosclock::host_now).doc(
+      "Get a ros::Time structure based on the NTP-corrected RT time or the ROS wall time.");
   rosclock->addOperation("rtt_now", &rtt_rosclock::rtt_now).doc(
       "Get a ros::Time structure based on the RTT time source.");
-  rosclock->addOperation("ros_now", &rtt_rosclock::ros_now).doc(
-      "Get a ros::Time structure based on the ROS time.");
-  rosclock->addOperation("host_rt_now", &rtt_rosclock::host_rt_now).doc(
-      "Get a ros::Time structure based on the NTP-corrected RT time. This is equivalent to the CLOCK_HOST_REALTIME clock source.");
+  rosclock->addOperation("rtt_wall_now", &rtt_rosclock::rtt_wall_now).doc(
+      "Get a ros::Time structure based on the RTT wall clock time.");
 
   // Getting time offset
-  rosclock->addOperation("host_rt_offset_from_rtt", &rtt_rosclock::host_rt_offset_from_rtt).doc(
-      "Get the difference between the Orocos clock and the ROS clock in seconds (host_time - rtt_time).");
+  rosclock->addOperation("host_offset_from_rtt", &rtt_rosclock::host_offset_from_rtt).doc(
+      "Get the difference between the Orocos wall clock and the NTP-corrected wall clock in seconds (host_wall - rtt_wall).");
 
   // Setting the source for the simulation clock
   rosclock->addOperation("useROSClockTopic", &rtt_rosclock::use_ros_clock_topic).doc(

--- a/rtt_rosdeployment/CMakeLists.txt
+++ b/rtt_rosdeployment/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(rtt_rosdeployment)
+
+find_package(catkin REQUIRED COMPONENTS roscpp rtt_ros rtt_ros_msgs) 
+
+include_directories(${catkin_INCLUDE_DIRS})
+
+orocos_use_package(ocl-deployment)
+
+orocos_plugin(rtt_rosdeployment src/rtt_rosdeployment_service.cpp)
+target_link_libraries(rtt_rosdeployment ${catkin_LIBRARIES})
+
+orocos_generate_package(
+  DEPENDS rtt_ros_msgs
+)

--- a/rtt_rosdeployment/README.md
+++ b/rtt_rosdeployment/README.md
@@ -1,0 +1,20 @@
+rtt_rosdeployment
+-----------------
+
+This package provides an easy way to interact with an Orocos deployment
+component over ROS. This uses ROS srv types in the
+[rtt_ros_msgs](../rtt_ros_msgs) package.
+
+## Supported Operations (C++ : ROS Service Name)
+
+* `DeploymentCompnent::runScript`:`run_script`
+* `DeploymentCompnent::getPeerList`:`get_peer_list`
+
+## Usage
+
+You can advertise the services from a deployment component like the following:
+
+```cpp
+import("rtt_rosdeployment");
+this.loadservice("rosdeployment");
+```

--- a/rtt_rosdeployment/package.xml
+++ b/rtt_rosdeployment/package.xml
@@ -1,0 +1,23 @@
+<package>
+  <name>rtt_rosdeployment</name>
+  <version>2.7.0</version>
+  <description>rtt_rosdeployment provides an RTT plugin to control an ocl deployment component over ROS service calls..</description>
+  <maintainer email="jbo@jhu.edu">Jonthan Bohren</maintainer>
+
+  <license>BSD</license>
+
+  <url type="website">http://ros.org/wiki/rtt_rospack</url>
+  <!-- <url type="bugtracker"></url> -->
+
+  <author email="jbo@jhu.edu">Jonthan Bohren</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>rtt_ros</build_depend> 
+  <build_depend>rtt_ros_msgs</build_depend> 
+  <build_depend>roscpp</build_depend> 
+
+  <run_depend>rtt_ros</run_depend> 
+  <run_depend>rtt_ros_msgs</run_depend> 
+  <run_depend>roscpp</run_depend> 
+</package>

--- a/rtt_rosdeployment/src/rtt_rosdeployment_service.cpp
+++ b/rtt_rosdeployment/src/rtt_rosdeployment_service.cpp
@@ -1,31 +1,3 @@
-/**
-*    This file is part of the OROCOS ROS integration project
-*
-*    (C) 2010 Ruben Smits, ruben.smits@mech.kuleuven.be, Department of Mechanical
-*    Engineering, Katholieke Universiteit Leuven, Belgium.
-*
-*    You may redistribute this software and/or modify it under either the terms of the GNU Lesser
-*    General Public License version 2.1
-*    (LGPLv2.1 <http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html>)
-*     or (at your discretion) of the Modified BSD License:
-*     Redistribution and use in source and binary forms, with or without modification, are permitted
-*     provided that the following conditions are met:
-*     1. Redistributions of source code must retain the above copyright notice, this list of 
-*      conditions and the following disclaimer.
-*     2. Redistributions in binary form must reproduce the above copyright notice, this list of 
-*      conditions and the following disclaimer in the documentation and/or other materials
-*      provided with the distribution.
-*     3. The name of the author may not be used to endorse or promote products derived from
-*      this software without specific prior written permission.
-*     THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
-*     BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-*     ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-*     EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-*     OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
-*     THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
-*     OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
-*     OF SUCH DAMAGE.
-**/
 
 #include <rtt/RTT.hpp>
 #include <rtt/plugin/Plugin.hpp>

--- a/rtt_rosdeployment/src/rtt_rosdeployment_service.cpp
+++ b/rtt_rosdeployment/src/rtt_rosdeployment_service.cpp
@@ -1,0 +1,138 @@
+/**
+*    This file is part of the OROCOS ROS integration project
+*
+*    (C) 2010 Ruben Smits, ruben.smits@mech.kuleuven.be, Department of Mechanical
+*    Engineering, Katholieke Universiteit Leuven, Belgium.
+*
+*    You may redistribute this software and/or modify it under either the terms of the GNU Lesser
+*    General Public License version 2.1
+*    (LGPLv2.1 <http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html>)
+*     or (at your discretion) of the Modified BSD License:
+*     Redistribution and use in source and binary forms, with or without modification, are permitted
+*     provided that the following conditions are met:
+*     1. Redistributions of source code must retain the above copyright notice, this list of 
+*      conditions and the following disclaimer.
+*     2. Redistributions in binary form must reproduce the above copyright notice, this list of 
+*      conditions and the following disclaimer in the documentation and/or other materials
+*      provided with the distribution.
+*     3. The name of the author may not be used to endorse or promote products derived from
+*      this software without specific prior written permission.
+*     THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+*     BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+*     ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+*     EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+*     OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
+*     THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
+*     OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+*     OF SUCH DAMAGE.
+**/
+
+#include <rtt/RTT.hpp>
+#include <rtt/plugin/Plugin.hpp>
+#include <rtt/plugin/ServicePlugin.hpp>
+#include <rtt/internal/GlobalService.hpp>
+
+#include <rtt_ros_msgs/RunScript.h>
+#include <rtt_ros_msgs/GetPeerList.h>
+
+#include <ocl/DeploymentComponent.hpp>
+
+#include <ros/ros.h>
+
+using namespace RTT;
+using namespace std;
+
+class ROSDeploymentService : public RTT::Service 
+{
+public:
+  ROSDeploymentService(OCL::DeploymentComponent* deployer);
+
+private:
+  OCL::DeploymentComponent *deployer_;
+
+  ros::NodeHandle nh_;
+
+  ros::ServiceServer run_script_service_;
+  ros::ServiceServer get_peer_list_service_;
+
+  bool run_script_cb(
+      rtt_ros_msgs::RunScript::Request& request,
+      rtt_ros_msgs::RunScript::Response& response);
+
+  bool get_peer_list_cb(
+      rtt_ros_msgs::GetPeerList::Request& request,
+      rtt_ros_msgs::GetPeerList::Response& response);
+};
+
+
+ROSDeploymentService::ROSDeploymentService(OCL::DeploymentComponent* deployer) :
+  Service("rosdeployment", static_cast<RTT::TaskContext*>(deployer)),
+  deployer_(deployer),
+  nh_("~"+deployer->getName())
+{
+  if(deployer_) {
+    // Create services
+    run_script_service_ = nh_.advertiseService("run_script",&ROSDeploymentService::run_script_cb,this);
+    get_peer_list_service_ = nh_.advertiseService("get_peer_list",&ROSDeploymentService::get_peer_list_cb,this);
+  } else {
+    RTT::log(RTT::Error) << "Attempted to load the rosdeployment service on a TaskContext which is not an OCL::DeploymentComponent. No ROS services will be advertised." << RTT::endlog();
+  }
+}
+
+bool ROSDeploymentService::run_script_cb(
+    rtt_ros_msgs::RunScript::Request& request,
+    rtt_ros_msgs::RunScript::Response& response)
+{
+  response.success = deployer_->runScript(request.file_path);
+  return true;
+}
+
+bool ROSDeploymentService::get_peer_list_cb(
+    rtt_ros_msgs::GetPeerList::Request& request,
+    rtt_ros_msgs::GetPeerList::Response& response)
+{
+  response.peers = deployer_->getPeerList();
+  return true;
+}
+
+bool loadROSDeploymentService(RTT::TaskContext *tc) {
+  OCL::DeploymentComponent *deployer = dynamic_cast<OCL::DeploymentComponent*>(tc);
+
+  if(!deployer) {
+    RTT::log(RTT::Error) << "The rosdeployment service must be loaded on a valid OCL::DeploymentComponent" <<RTT::endlog();
+    return false; 
+  }
+
+  deployer->import("rtt_rosnode");
+
+  if(!ros::isInitialized()) {
+    RTT::log(RTT::Error) << "The rtt_rosdeployment plugin cannot be used without the rtt_rosnode plugin. Please load rtt_rosnode." << RTT::endlog();
+
+    return false;
+  }
+
+  RTT::Service::shared_ptr sp( new ROSDeploymentService( deployer ) ); 
+  return tc->provides()->addService( sp ); 
+}
+
+extern "C" {
+  RTT_EXPORT bool loadRTTPlugin(RTT::TaskContext* tc);  
+  bool loadRTTPlugin(RTT::TaskContext* tc) {    
+    if(tc == 0) return true;
+    return loadROSDeploymentService(tc);
+  } 
+  RTT_EXPORT RTT::Service::shared_ptr createService();  
+  RTT::Service::shared_ptr createService() {    
+    RTT::Service::shared_ptr sp; 
+    return sp; 
+  } 
+  RTT_EXPORT std::string getRTTPluginName(); 
+  std::string getRTTPluginName() { 
+    return "rosdeployment"; 
+  } 
+  RTT_EXPORT std::string getRTTTargetName(); 
+  std::string getRTTTargetName() { 
+    return OROCOS_TARGET_NAME; 
+  } 
+}
+


### PR DESCRIPTION
- **rtt_tf:** Adding `canTransform` RTT_TF operation
- **rtt_rosparam:** Adding `getParam` and `setParam` for getting and setting params which have different names (or namespaces) from their property names
- **rtt_rosdeployment:** Adding a plugin which lets you manipulate an OCC::DeploymentComponent over ROS service calls (like run scripts, list components, etc)
- **rtt_ros_msgs:** .srv types used by rtt_rosdeployment
- **rtt_rosclock:** **_significant change see new rtt_rosclock README.md**_ clarifying which operations handle wall time vs sim time 
