### PR TITLE
rtt_tf: removed authority setting from header callerid of tf messages for ROS indigo and upwards

### DIFF
--- a/rtt_tf/rtt_tf-component.cpp
+++ b/rtt_tf/rtt_tf-component.cpp
@@ -134,6 +134,9 @@ namespace rtt_tf
           StampedTransform trans;
           transformStampedMsgToTF(msg_in.transforms[i], trans);
           try {
+#if ROS_VERSION_MINIMUM(1,11,0)
+            this->setTransform(trans);
+#else
             std::map<std::string, std::string>* msg_header_map =
               msg_in.__connection_header.get();
             std::string authority;
@@ -147,6 +150,7 @@ namespace rtt_tf
               authority = it->second;
             }
             this->setTransform(trans, authority);
+#endif
           } catch (TransformException& ex) {
             log(Error) << "Failure to set received transform from "
               << msg_in.transforms[i].child_frame_id << " to "


### PR DESCRIPTION
This patch fixes the compile errors of rtt_tf in ROS indigo. The connection header is no longer a member variable of the message instance and can therefore not be forwarded through a port connection and used as tf authority. However, this should only have an effect on the log messages and not influence the functionality of the `tf::Transformer`.
