### PR TITLE
rtt_dynamic_reconfigure: added support for Property composition and decomposition and fixed reconfiguration of nested properties

### DIFF
--- a/rtt_dynamic_reconfigure/include/orocos/rtt_dynamic_reconfigure/auto_config.h
+++ b/rtt_dynamic_reconfigure/include/orocos/rtt_dynamic_reconfigure/auto_config.h
@@ -76,6 +76,9 @@ public:
 
     static void __refreshDescription__(const ServerType *server);
 
+    bool updateProperties(RTT::PropertyBag &) const;
+    bool fromProperties(const RTT::PropertyBag &);
+
 private:
     struct Cache;
     typedef boost::shared_ptr<Cache> CachePtr;
@@ -100,8 +103,8 @@ namespace rtt_dynamic_reconfigure {
 
 template <>
 struct Updater<AutoConfig> {
-    static bool propertiesFromConfig(AutoConfig &config, uint32_t, RTT::PropertyBag &bag) { return RTT::updateProperties(bag, config); }
-    static bool configFromProperties(AutoConfig &config, const RTT::PropertyBag &bag)     { return RTT::updateProperties(config, bag); }
+    static bool propertiesFromConfig(AutoConfig &config, uint32_t, RTT::PropertyBag &bag) { return config.updateProperties(bag); }
+    static bool configFromProperties(AutoConfig &config, const RTT::PropertyBag &bag)     { return config.fromProperties(bag); }
 };
 
 template <>
@@ -120,7 +123,7 @@ struct dynamic_reconfigure_traits<AutoConfig> {
     static void fromMessage(AutoConfig &config, dynamic_reconfigure::Config &message, const ServerType *server) { config.__fromMessage__(message, config); }
     static void clamp(AutoConfig &config, const ServerType *server) { config.__clamp__(server); }
 
-    static RTT::internal::AssignableDataSource<RTT::PropertyBag>::shared_ptr toPropertyBag(AutoConfig &config, const ServerType *) {
+    static RTT::internal::AssignableDataSource<RTT::PropertyBag>::shared_ptr getDataSource(AutoConfig &config, const ServerType *) {
         return RTT::internal::AssignableDataSource<RTT::PropertyBag>::shared_ptr(new RTT::internal::ReferenceDataSource<RTT::PropertyBag>(config));
     }
 };

--- a/rtt_dynamic_reconfigure/include/orocos/rtt_dynamic_reconfigure/server.h
+++ b/rtt_dynamic_reconfigure/include/orocos/rtt_dynamic_reconfigure/server.h
@@ -142,12 +142,12 @@ struct dynamic_reconfigure_traits {
     static void clamp(ConfigType &config, const ServerType *) { config.__clamp__(); }
 
     /**
-     * Create a new RTT::internal::ValueDataSource<RTT::PropertyBag> filled with properties from a ConfigType instance.
+     * Creates a new RTT::internal::AssignableDataSource<RTT::PropertyBag> filled with properties from a ConfigType instance.
      *
      * \param config referencte to the ConfigType instance to be read
      * \param server pointer to the rtt_dynamic_reconfigure server instance whose updater is going to be used
      */
-    static RTT::internal::AssignableDataSource<RTT::PropertyBag>::shared_ptr toPropertyBag(ConfigType &config, const ServerType *server) {
+    static RTT::internal::AssignableDataSource<RTT::PropertyBag>::shared_ptr getDataSource(ConfigType &config, const ServerType *server) {
         RTT::internal::AssignableDataSource<RTT::PropertyBag>::shared_ptr ds(new RTT::internal::ValueDataSource<RTT::PropertyBag>());
         if (!server->updater()->propertiesFromConfig(config, ~0, ds->set()))
             ds.reset();
@@ -439,9 +439,9 @@ public:
         this->properties()->remove(this->properties()->getProperty("min"));
         this->properties()->remove(this->properties()->getProperty("max"));
         this->properties()->remove(this->properties()->getProperty("default"));
-        this->properties()->ownProperty(new RTT::Property<RTT::PropertyBag>("min", "Minimum values as published to dynamic_reconfigure clients", traits::toPropertyBag(min_, this)));
-        this->properties()->ownProperty(new RTT::Property<RTT::PropertyBag>("max", "Maximum values as published to dynamic_reconfigure clients", traits::toPropertyBag(max_, this)));
-        this->properties()->ownProperty(new RTT::Property<RTT::PropertyBag>("default", "Default values as published to dynamic_reconfigure clients", traits::toPropertyBag(default_, this)));
+        this->properties()->ownProperty(new RTT::Property<RTT::PropertyBag>("min", "Minimum values as published to dynamic_reconfigure clients", traits::getDataSource(min_, this)));
+        this->properties()->ownProperty(new RTT::Property<RTT::PropertyBag>("max", "Maximum values as published to dynamic_reconfigure clients", traits::getDataSource(max_, this)));
+        this->properties()->ownProperty(new RTT::Property<RTT::PropertyBag>("default", "Default values as published to dynamic_reconfigure clients", traits::getDataSource(default_, this)));
 
         // Get initial values from current property settings
         config_ = ConfigType();

--- a/rtt_dynamic_reconfigure/src/auto_config.cpp
+++ b/rtt_dynamic_reconfigure/src/auto_config.cpp
@@ -35,6 +35,7 @@
 #include <rtt_dynamic_reconfigure/auto_config.h>
 #include <rtt/Property.hpp>
 #include <rtt/internal/DataSources.hpp>
+#include <rtt/types/PropertyComposition.hpp>
 
 #include <climits>
 #include <cfloat>
@@ -104,8 +105,8 @@ AutoConfig::AutoConfig()
 }
 
 AutoConfig::AutoConfig(const RTT::PropertyBag &bag)
-    : RTT::PropertyBag(bag)
 {
+    this->fromProperties(bag);
 }
 
 AutoConfig::~AutoConfig()
@@ -222,6 +223,23 @@ bool AutoConfig::__fromMessage__(AutoConfig &config, Config &msg, const AutoConf
         RTT::base::PropertyBase *pb = config.getProperty((*i)->getName());
         std::string param_name = config.prefix_ + (*i)->getName();
 
+        // For sub groups, add a sub config to *this and recurse...
+        const AutoConfig *sample_sub = getAutoConfigFromProperty(*i);
+        if (sample_sub) {
+            RTT::Property<RTT::PropertyBag> *sub = config.getPropertyType<RTT::PropertyBag>((*i)->getName());
+            AutoConfigDataSource *ds;
+            if (sub) {
+                ds = AutoConfigDataSource::narrow(sub->getDataSource().get());
+            } else {
+                ds = new AutoConfigDataSource();
+                sub = new RTT::Property<RTT::PropertyBag>((*i)->getName(), (*i)->getDescription(), AutoConfigDataSource::shared_ptr(ds));
+                config.ownProperty(sub);
+            }
+
+            if (ds && __fromMessage__(ds->set(), msg, *sample_sub))
+                continue;
+        }
+
         // search parameter in Config message
         bool param_found = false;
         for(Config::_bools_type::const_iterator n = msg.bools.begin(); n != msg.bools.end(); ++n) {
@@ -247,23 +265,6 @@ bool AutoConfig::__fromMessage__(AutoConfig &config, Config &msg, const AutoConf
             propertyFromMessage<double>(config, msg, *i, param_name) ||
             propertyFromMessage<float>(config, msg, *i, param_name)
            ) continue;
-
-        // For sub groups, add a sub config to *this and recurse...
-        const AutoConfig *sample_sub = getAutoConfigFromProperty(*i);
-        if (sample_sub) {
-            RTT::Property<RTT::PropertyBag> *sub = config.getPropertyType<RTT::PropertyBag>((*i)->getName());
-            AutoConfigDataSource *ds;
-            if (sub) {
-                ds = AutoConfigDataSource::narrow(sub->getDataSource().get());
-            } else {
-                ds = new AutoConfigDataSource();
-                sub = new RTT::Property<RTT::PropertyBag>((*i)->getName(), (*i)->getDescription(), AutoConfigDataSource::shared_ptr(ds));
-                config.ownProperty(sub);
-            }
-
-            if (ds && __fromMessage__(ds->set(), msg, *sample_sub))
-                continue;
-        }
 
         result = false;
     }
@@ -337,6 +338,39 @@ uint32_t AutoConfig::__level__(const AutoConfig &config) const
     return 0;
 }
 
+bool AutoConfig::updateProperties(RTT::PropertyBag &target) const
+{
+    RTT::PropertyBag composed;
+    if (!RTT::types::composePropertyBag(*this, composed)) return false;
+    return RTT::updateProperties(target, composed);
+}
+
+bool AutoConfig::fromProperties(const RTT::PropertyBag &source)
+{
+    RTT::PropertyBag decomposed;
+    if (!RTT::types::decomposePropertyBag(source, decomposed)) return false;
+
+    for(RTT::PropertyBag::const_iterator i = decomposed.begin(); i != decomposed.end(); ++i) {
+        RTT::base::PropertyBase *pb = this->getProperty((*i)->getName());
+        if (pb) {
+            pb->update(*i);
+            continue;
+        }
+
+        RTT::Property<RTT::PropertyBag> *sub = dynamic_cast<RTT::Property<RTT::PropertyBag> *>(*i);
+        if (sub) {
+            AutoConfigDataSource *ds = new AutoConfigDataSource(sub->rvalue());
+            ds->set().setType(sub->rvalue().getType());
+            this->ownProperty(new RTT::Property<RTT::PropertyBag>(sub->getName(), sub->getDescription(), ds));
+            continue;
+        } else {
+            this->ownProperty((*i)->clone());
+        }
+    }
+
+    return true;
+}
+
 template <typename T>
 static bool buildParamDescription(const RTT::base::PropertyBase *pb, const std::string &prefix, Group::_parameters_type& params, AutoConfig& dflt, AutoConfig& min, AutoConfig& max)
 {
@@ -371,7 +405,7 @@ static bool buildParamDescription(const RTT::base::PropertyBase *pb, const std::
     return true;
 }
 
-static void buildGroupDescription(RTT::TaskContext *owner, const RTT::PropertyBag *bag, ConfigDescription& config_description, AutoConfig& dflt, AutoConfig& min, AutoConfig& max, const std::string &prefix, const std::string &name, const std::string &type, int32_t parent, int32_t id)
+static void buildGroupDescription(RTT::TaskContext *owner, const RTT::PropertyBag &bag, ConfigDescription& config_description, AutoConfig& dflt, AutoConfig& min, AutoConfig& max, const std::string &prefix, const std::string &name, const std::string &type, int32_t parent, int32_t id)
 {
     std::size_t group_index = config_description.groups.size();
     config_description.groups.push_back(Group());
@@ -404,7 +438,7 @@ static void buildGroupDescription(RTT::TaskContext *owner, const RTT::PropertyBa
     max.state = true;
 
     // for loop might invalidate group reference -> use index group_index instead
-    for(RTT::PropertyBag::const_iterator i = bag->begin(); i != bag->end(); ++i) {
+    for(RTT::PropertyBag::const_iterator i = bag.begin(); i != bag.end(); ++i) {
         if (buildParamDescription<bool>(*i, prefix, config_description.groups[group_index].parameters, dflt, min, max) ||
             buildParamDescription<int>(*i, prefix, config_description.groups[group_index].parameters, dflt, min, max) ||
             buildParamDescription<unsigned int>(*i, prefix, config_description.groups[group_index].parameters, dflt, min, max) ||
@@ -419,6 +453,7 @@ static void buildGroupDescription(RTT::TaskContext *owner, const RTT::PropertyBa
             if (!sub_dflt) {
                 AutoConfigDataSource *ds = new AutoConfigDataSource();
                 sub_dflt = &(ds->set());
+                sub_dflt->setType(sub->rvalue().getType());
                 dflt.ownProperty(new RTT::Property<RTT::PropertyBag>(sub->getName(), sub->getDescription(), ds));
             }
 
@@ -426,6 +461,7 @@ static void buildGroupDescription(RTT::TaskContext *owner, const RTT::PropertyBa
             if (!sub_min) {
                 AutoConfigDataSource *ds = new AutoConfigDataSource();
                 sub_min = &(ds->set());
+                sub_min->setType(sub->rvalue().getType());
                 min.ownProperty(new RTT::Property<RTT::PropertyBag>(sub->getName(), sub->getDescription(), ds));
             }
 
@@ -433,10 +469,11 @@ static void buildGroupDescription(RTT::TaskContext *owner, const RTT::PropertyBa
             if (!sub_max) {
                 AutoConfigDataSource *ds = new AutoConfigDataSource();
                 sub_max = &(ds->set());
+                sub_max->setType(sub->rvalue().getType());
                 max.ownProperty(new RTT::Property<RTT::PropertyBag>(sub->getName(), sub->getDescription(), ds));
             }
 
-            buildGroupDescription(owner, &(sub->rvalue()), config_description, *sub_dflt, *sub_min, *sub_max, prefix + sub->getName() + "__", prefix + sub->getName(), "", config_description.groups[group_index].id, ++id);
+            buildGroupDescription(owner, sub->rvalue(), config_description, *sub_dflt, *sub_min, *sub_max, prefix + sub->getName() + "__", prefix + sub->getName(), "", config_description.groups[group_index].id, ++id);
         }
     }
 }
@@ -446,6 +483,12 @@ boost::shared_mutex AutoConfig::cache_mutex_;
 
 void AutoConfig::buildCache(const ServerType *server, RTT::TaskContext *owner)
 {
+    RTT::PropertyBag decomposed;
+    if (!RTT::types::decomposePropertyBag(*(owner->properties()), decomposed)) {
+        RTT::log(RTT::Error) << "Failed to decompose properties of '" << owner->getName() << "' for dynamic_reconfigure. Properties with custom types will not be available for reconfiguration." << RTT::endlog();
+        decomposed = *(owner->properties());
+    }
+
     boost::upgrade_lock<boost::shared_mutex> upgrade_lock(cache_mutex_);
     if (upgrade_lock.owns_lock())
     {
@@ -453,7 +496,7 @@ void AutoConfig::buildCache(const ServerType *server, RTT::TaskContext *owner)
         CachePtr& cache = cache_[server];
         if (!cache) cache.reset(new Cache());
         cache->description_message_.reset(new ConfigDescription);
-        buildGroupDescription(owner, owner->properties(), *(cache->description_message_), cache->default_, cache->min_, cache->max_, "", "", "", 0, 0);
+        buildGroupDescription(owner, decomposed, *(cache->description_message_), cache->default_, cache->min_, cache->max_, "", "", "", 0, 0);
     }
 }
 

--- a/tests/rtt_dynamic_reconfigure_tests/CMakeLists.txt
+++ b/tests/rtt_dynamic_reconfigure_tests/CMakeLists.txt
@@ -12,13 +12,17 @@ if(CATKIN_ENABLE_TESTING)
   orocos_plugin(rtt_dynamic_reconfigure_tests_service test/service.cpp)
   add_dependencies(rtt_dynamic_reconfigure_tests_service ${PROJECT_NAME}_gencfg)
 
+  orocos_component(rtt_dynamic_reconfigure_tests_component test/test_component.cpp)
+
   catkin_add_gtest(rtt_dynamic_reconfigure_tests test/rtt_dynamic_reconfigure_tests.cpp)
   add_dependencies(rtt_dynamic_reconfigure_tests rtt_dynamic_reconfigure_tests_service)
   target_link_libraries(rtt_dynamic_reconfigure_tests
     ${catkin_LIBRARIES}
     ${USE_OROCOS_LIBRARIES}
     ${OROCOS-RTT_LIBRARIES}
-    ${OROCOS-RTT_RTT-SCRIPTING_LIBRARY} )
+    ${OROCOS-RTT_RTT-SCRIPTING_LIBRARY}
+    rtt_dynamic_reconfigure_tests_component
+  )
 
   orocos_generate_package()
 

--- a/tests/rtt_dynamic_reconfigure_tests/package.xml
+++ b/tests/rtt_dynamic_reconfigure_tests/package.xml
@@ -13,14 +13,17 @@
 
   <build_depend>rtt_ros</build_depend>
   <build_depend>rtt_dynamic_reconfigure</build_depend>
+  <build_depend>rtt_geometry_msgs</build_depend>
 
   <run_depend>rtt_ros</run_depend>
   <run_depend>rtt_dynamic_reconfigure</run_depend>
+  <run_depend>rtt_geometry_msgs</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <rtt_ros>
       <plugin_depend>rtt_dynamic_reconfigure</plugin_depend>
+      <plugin_depend>rtt_geometry_msgs</plugin_depend>
     </rtt_ros>
   </export>
 

--- a/tests/rtt_dynamic_reconfigure_tests/test/test_component.cpp
+++ b/tests/rtt_dynamic_reconfigure_tests/test/test_component.cpp
@@ -1,0 +1,11 @@
+/*********************************************************************
+ *
+ *  Copyright (c) 2015, Intermodalics BVBA
+ *  All rights reserved.
+ *
+ *********************************************************************/
+
+#include <rtt/Component.hpp>
+#include "test_component.hpp"
+
+ORO_CREATE_COMPONENT(DynamicReconfigureTestComponent)

--- a/tests/rtt_dynamic_reconfigure_tests/test/test_component.hpp
+++ b/tests/rtt_dynamic_reconfigure_tests/test/test_component.hpp
@@ -1,0 +1,71 @@
+/*********************************************************************
+ *
+ *  Copyright (c) 2015, Intermodalics BVBA
+ *  All rights reserved.
+ *
+ *********************************************************************/
+
+#ifndef RTT_DYNAMIC_RECONFIGURE_TESTS_TEST_COMPONENT_HPP
+#define RTT_DYNAMIC_RECONFIGURE_TESTS_TEST_COMPONENT_HPP
+
+#include <rtt/TaskContext.hpp>
+#include <geometry_msgs/Vector3.h>
+
+struct Properties {
+    Properties()
+    : int_param()
+    , double_param()
+    , str_param()
+    , bool_param()
+    , float_param()
+    , uint_param()
+    , bag_param()
+    , str_param_in_bag()
+    , vector3_param()
+    {}
+
+    int int_param;
+    double double_param;
+    std::string str_param;
+    bool bool_param;
+
+    // other property types
+    float float_param;
+    unsigned int uint_param;
+
+    // PropertyBag properties
+    RTT::PropertyBag bag_param;
+    std::string str_param_in_bag;
+
+    // composable properties
+    geometry_msgs::Vector3 vector3_param;
+};
+
+class DynamicReconfigureTestComponent : public RTT::TaskContext
+{
+public:
+    Properties props;
+
+    // types directly supported by dynamic_reconfigure
+    DynamicReconfigureTestComponent(const std::string &name = "component")
+        : RTT::TaskContext(name)
+    {
+        this->addProperty("int_param", props.int_param);
+        this->addProperty("double_param", props.double_param);
+        this->addProperty("str_param", props.str_param);
+        this->addProperty("bool_param", props.bool_param);
+
+        this->addProperty("float_param", props.float_param);
+        this->addProperty("uint_param", props.uint_param);
+
+        props.bag_param.addProperty("str_param", props.str_param_in_bag);
+        this->addProperty("bag_param", props.bag_param);
+
+        props.vector3_param.x = 1.0;
+        props.vector3_param.y = 2.0;
+        props.vector3_param.z = 3.0;
+        this->addProperty("vector3_param", props.vector3_param);
+    }
+};
+
+#endif // RTT_DYNAMIC_RECONFIGURE_TESTS_TEST_COMPONENT_HPP


### PR DESCRIPTION
Reconfiguration of nested properties (properties inside a PropertyBag) was broken because `AutoConfig::__fromMessage__()` aborted too early if a property name was not found in the Config message, even if it is the name of a nested bag.

Composition support now allows to use the reconfigure service even for properties with complex types that support composition (e.g. types from kdl_typekit or eigen_typekit).

This patch also applies to indigo-devel. I will merge it as soon as it has been accepted for hydro.
