### PR TITLE
add Corba deployer scripts

### DIFF
--- a/rtt_ros/launch/deployer.launch
+++ b/rtt_ros/launch/deployer.launch
@@ -9,16 +9,26 @@
   <arg name="OROCOS_TARGET" default="$(optenv OROCOS_TARGET)"/>
   <!-- Path to look for dynamically-loaded plugins and components (something like /lib/orocos) -->
   <arg name="RTT_COMPONENT_PATH" default="$(env RTT_COMPONENT_PATH)"/>
-
+  <!-- Lauch corba deployer -->
+  <arg name="CORBA" default="false"/>
   <!-- Set DEBUG to true to run in GDB (don't forget to build in Debug mode) -->
   <arg name="DEBUG" default="false"/>
   <arg if="$(arg DEBUG)" name="SUFFIX" value="-debug"/>
   <arg unless="$(arg DEBUG)" name="SUFFIX" value=""/>
 
   <!-- Launch deployer -->
-  <node 
+  <node unless="$(arg CORBA)"
     name="$(arg NAME)"
     pkg="rtt_ros" type="deployer$(arg SUFFIX)" 
+    args="-l $(arg LOG_LEVEL) $(arg DEPLOYER_ARGS) --"
+    output="screen">
+    <env name="OROCOS_TARGET" value="$(arg OROCOS_TARGET)"/>
+    <env name="RTT_COMPONENT_PATH" value="$(arg RTT_COMPONENT_PATH)"/>
+  </node>
+  <!-- launch corba deployer -->
+  <node if="$(arg CORBA)"
+    name="$(arg NAME)"
+    pkg="rtt_ros" type="deployer-corba$(arg SUFFIX)" 
     args="-l $(arg LOG_LEVEL) $(arg DEPLOYER_ARGS) --"
     output="screen">
     <env name="OROCOS_TARGET" value="$(arg OROCOS_TARGET)"/>

--- a/rtt_ros/scripts/deployer-corba
+++ b/rtt_ros/scripts/deployer-corba
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# Wrapper script for the orocos deployer
+
+deployer-corba "$@"

--- a/rtt_ros/scripts/deployer-corba-debug
+++ b/rtt_ros/scripts/deployer-corba-debug
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Wrapper script for the orocos deployer debug
+
+# Use gnulinux if orocos target isn't set
+OROCOS_TARGET=${OROCOS_TARGET:-gnulinux}
+
+# Run with gdb
+gdb -ex run --args deployer-corba-$OROCOS_TARGET "$@"


### PR DESCRIPTION
This just add the corba deployer : 

```
rosrun rtt_ros deployer-corba
roslaunch rtt_ros deployer.launch CORBA=true
```

As for practical aspects, I find easier to provide an argument to the launch file than creating another file (deployer-corba.launch).
