### PR TITLE
Build and test in a Travis trusty environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,11 @@
-language:
-  - cpp
-  - python
-  - ruby
-  - lua
-python:
-  - "2.7"
+sudo: required
+dist: trusty
+language: generic
 compiler:
   - gcc
 before_install:
   # Define some config vars
-  - export ROS_DISTRO=hydro
+  - export ROS_DISTRO=indigo
   - export CI_SOURCE_PATH=$(pwd)
   # Bootstrap a minimal ROS installation
   - git clone https://github.com/jhu-lcsr/ros_ci_tools /tmp/ros_ci_tools && export PATH=/tmp/ros_ci_tools:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - export ROS_DISTRO=indigo
   - export CI_SOURCE_PATH=$(pwd)
   # Bootstrap a minimal ROS installation
-  - git clone https://github.com/jhu-lcsr/ros_ci_tools /tmp/ros_ci_tools && export PATH=/tmp/ros_ci_tools:$PATH
+  - git clone https://github.com/orocos/ros_ci_tools /tmp/ros_ci_tools && export PATH=/tmp/ros_ci_tools:$PATH
   - ros_ci_bootstrap
   - source /opt/ros/$ROS_DISTRO/setup.bash
   # Create non-isolated workspace


### PR DESCRIPTION
The tests in package [rtt_dynamic_reconfigure_tests](https://github.com/orocos/rtt_ros_integration/tree/indigo-devel/tests/rtt_dynamic_reconfigure_tests) in the indigo-devel branch fail if rtt_ros_integration is built with ROS hydro. Trusty with ROS indigo seems to work: https://travis-ci.org/orocos/rtt_ros_integration/builds/89081040

See http://docs.travis-ci.com/user/trusty-ci-environment/.
This patch follows the suggestion in http://lists.ros.org/pipermail/ros-users/2015-October/069721.html.
