### PR TITLE
Added explicit destructors to fix #59

### DIFF
--- a/rtt_roscomm/include/rtt_roscomm/rtt_rosservice_proxy.h
+++ b/rtt_roscomm/include/rtt_roscomm/rtt_rosservice_proxy.h
@@ -11,6 +11,7 @@ class ROSServiceProxyBase
 {
 public:
   ROSServiceProxyBase(const std::string &service_name) : service_name_(service_name) { }
+  virtual ~ROSServiceProxyBase() { }
   //! Get the name of the ROS service
   const std::string& getServiceName() const { return service_name_; }
 private:

--- a/rtt_roscomm/include/rtt_roscomm/rtt_rosservice_proxy.h
+++ b/rtt_roscomm/include/rtt_roscomm/rtt_rosservice_proxy.h
@@ -67,6 +67,12 @@ public:
         this);
   }
 
+  ~ROSServiceServerProxy()
+  {
+    // Clean-up advertized ROS services
+    server_.shutdown();     
+  }
+
 private:
   
   //! The callback called by the ROS service server when this service is invoked

--- a/rtt_roscomm/src/rtt_rosservice_service.cpp
+++ b/rtt_roscomm/src/rtt_rosservice_service.cpp
@@ -38,6 +38,22 @@ public:
     get_service_factory = rosservice_registry_->getOperation("getServiceFactory");
   }
 
+  ~ROSServiceService()
+  {
+    // Cleanup registered ROS services and clients
+    std::map<std::string, ROSServiceServerProxyBase*>::iterator iter_s;
+    for(iter_s=server_proxies_.begin(); iter_s != server_proxies_.end(); iter_s++)
+    {
+      delete iter_s->second;
+    }
+
+    std::map<std::string, ROSServiceClientProxyBase*>::iterator iter_c;
+    for(iter_c=client_proxies_.begin(); iter_c != client_proxies_.end(); iter_c++)
+    {
+      delete iter_c->second;
+    }
+  }
+
   //! Get an RTT operation caller from a string identifier
   RTT::base::OperationCallerBaseInvoker* get_owner_operation_caller(const std::string rtt_uri)
   {


### PR DESCRIPTION
Following suggestions in #59 , I added two explicit destructors. Adding only the one in the proxy did not suffice as the pointers stored in the map were not explicitly deleted. 

Changing to shared_ptr seemed like a risky think to do for me, and would cause API change as far as I understand. Not an expert, so I am not usre if my change is an ABI change, but at least it is not an API change. 

If everything is ok for you, then I am interested to have this fix back-ported to indigo if possible.
