### PR TITLE
rtt_roscomm: avoid mismatched-tags warning in clang…

### DIFF
--- a/rtt_roscomm/src/templates/typekit/msg_Types.hpp.in
+++ b/rtt_roscomm/src/templates/typekit/msg_Types.hpp.in
@@ -8,7 +8,6 @@
 
 // All these classes were generated in the typekit library:
 #ifdef CORELIB_DATASOURCE_HPP
-    extern template class RTT::internal::DataSourceTypeInfo< @ROSMSGTYPE@ >;
     extern template class RTT::internal::DataSource< @ROSMSGTYPE@ >;
     extern template class RTT::internal::AssignableDataSource< @ROSMSGTYPE@ >;
     extern template class RTT::internal::AssignCommand< @ROSMSGTYPE@ >;

--- a/rtt_roscomm/src/templates/typekit/ros_msg_typekit_plugin.cpp.in
+++ b/rtt_roscomm/src/templates/typekit/ros_msg_typekit_plugin.cpp.in
@@ -7,7 +7,6 @@
 
 // Note: we need to put these up-front or we get gcc compiler warnings:
 // <<warning: type attributes ignored after type is already defined>>        
-template class RTT_EXPORT RTT::internal::DataSourceTypeInfo< @ROSMSGTYPE@ >;
 template class RTT_EXPORT RTT::internal::DataSource< @ROSMSGTYPE@ >;
 template class RTT_EXPORT RTT::internal::AssignableDataSource< @ROSMSGTYPE@ >;
 template class RTT_EXPORT RTT::internal::AssignCommand< @ROSMSGTYPE@ >;


### PR DESCRIPTION
… by removing the extern template declaration and instantiation for `RTT::internal::DataSourceTypeInfo<T>`.

`RTT::internal::DataSourceTypeInfo<T>` is declared as a struct in [rtt/internal/DataSourceTypeInfo.hpp](https://github.com/orocos-toolchain/rtt/tree/master/rtt/internal/DataSourceTypeInfo.hpp). Apparently clang and VC issue a `mismatched-tags` warning if struct/class tags do not match.

`DataSourceTypeInfo<T>` is actually only a thin wrapper to lookup the type name and TypeInfo from derived pointer and reference types. On the other hand, there are a lot more template classes that could be declared extern as part of the typekit, e.g. for vectors or arrays of messages.

See [rtt/typekit/Types.hpp](https://github.com/orocos-toolchain/rtt/tree/master/rtt/typekit/Types.hpp) for a list of extern template declarations for the native RTT typekit.
