### PR TITLE
rtt_roscomm: fixed destruction of RosSubChannelElement<T> and ROS subscriber shutdown

### DIFF
--- a/rtt_roscomm/include/rtt_roscomm/rtt_rostopic_ros_msg_transporter.hpp
+++ b/rtt_roscomm/include/rtt_roscomm/rtt_rostopic_ros_msg_transporter.hpp
@@ -214,7 +214,6 @@ namespace rtt_roscomm {
       } else {
         ros_sub = ros_node.subscribe(policy.name_id,policy.size,&RosSubChannelElement::newData,this);
       }
-      this->ref();
     }
 
     ~RosSubChannelElement() {

--- a/tests/rtt_roscomm_tests/test/transport_tests.cpp
+++ b/tests/rtt_roscomm_tests/test/transport_tests.cpp
@@ -10,10 +10,17 @@
 #include <rtt_roscomm/rtt_rostopic.h>
 #include <std_msgs/typekit/String.h>
 
+#include <ros/names.h>
+#include <ros/this_node.h>
+
 #include <gtest/gtest.h>
+
+#include <algorithm>
 
 TEST(TransportTest, OutOfBandTest)
 {
+  ros::V_string advertised_topics, subscribed_topics;
+
   // Import plugins
   EXPECT_TRUE(RTT::ComponentLoader::Instance()->import("rtt_std_msgs", "" ));
   EXPECT_TRUE(RTT::ComponentLoader::Instance()->import("rtt_rosnode", "" ));
@@ -22,17 +29,43 @@ TEST(TransportTest, OutOfBandTest)
   RTT::InputPort<std_msgs::String> in("in");
 
   // Create an out-of-band connection with ROS transport (a publisher/subscriber pair)
-  EXPECT_TRUE(out.connectTo(&in, rtt_roscomm::topicLatched("~talker")));
+  std::string topic = ros::names::resolve("~talker");
+  EXPECT_TRUE(out.connectTo(&in, rtt_roscomm::topicLatched(topic)));
 
+  // Check that the publisher and subscriber have been successfully registered:
+  ros::this_node::getAdvertisedTopics(advertised_topics);
+  EXPECT_TRUE(std::find(advertised_topics.begin(), advertised_topics.end(),
+                        topic) != advertised_topics.end());
+  ros::this_node::getSubscribedTopics(subscribed_topics);
+  EXPECT_TRUE(std::find(subscribed_topics.begin(), subscribed_topics.end(),
+                        topic) != subscribed_topics.end());
+
+  // publish and latch one sample
   std_msgs::String sample;
   sample.data = "Hello world!";
   out.write(sample);
 
   usleep(1000000);
 
+  // read sample through input port
   sample.data.clear();
   EXPECT_EQ(RTT::NewData, in.read(sample) );
   EXPECT_EQ("Hello world!", sample.data);
+
+  // Close connection
+  out.disconnect();
+  EXPECT_FALSE(out.connected());
+  EXPECT_FALSE(in.connected());
+
+  // Check that the publisher and subscriber have been destroyed:
+  advertised_topics.clear();
+  subscribed_topics.clear();
+  ros::this_node::getAdvertisedTopics(advertised_topics);
+  EXPECT_FALSE(std::find(advertised_topics.begin(), advertised_topics.end(),
+                        topic) != advertised_topics.end());
+  ros::this_node::getSubscribedTopics(subscribed_topics);
+  EXPECT_FALSE(std::find(subscribed_topics.begin(), subscribed_topics.end(),
+                        topic) != subscribed_topics.end());
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
From https://github.com/orocos/rtt_ros_integration/issues/61#issuecomment-232110035:

> @meyerj: I found that rtt_rostopic_ros_msg_transporter.hpp:217 is responsible for increasing the reference count of the RosSubChannelElement<T> instance and therefore it will never be deleted. At least in RTT 2.9 connection cleanup should work properly without this line and I verified by adding a check to rtt_roscomm_tests that the publishers and subscribers are properly shutdown after a port disconnect.

@smits, do you remember why this line was necessary back in 2010?

Commit 36ac69621e6e3fa41b7afe4dfd6eebff47a01c1d is the one-line fix based on indigo-devel, while e6ef1cc5844b3a733008204f57b6b65bbde03b12 amends the transport test in rtt_roscomm_tests to check the advertised and subscribed topics via the roscpp API before and after connection cleanup. The branch also compiles and all tests run successfully with the RTT/OCL version 2.8.2 released in ROS indigo.
