### PR TITLE
rtt_dynamic_reconfigure: fixed potential deadlock in refresh() for RTT prior to 2.9

### DIFF
--- a/tests/rtt_dynamic_reconfigure_tests/CMakeLists.txt
+++ b/tests/rtt_dynamic_reconfigure_tests/CMakeLists.txt
@@ -16,13 +16,8 @@ if(CATKIN_ENABLE_TESTING)
 
   catkin_add_gtest(rtt_dynamic_reconfigure_tests test/rtt_dynamic_reconfigure_tests.cpp)
   add_dependencies(rtt_dynamic_reconfigure_tests rtt_dynamic_reconfigure_tests_service)
-  target_link_libraries(rtt_dynamic_reconfigure_tests
-    ${catkin_LIBRARIES}
-    ${USE_OROCOS_LIBRARIES}
-    ${OROCOS-RTT_LIBRARIES}
-    ${OROCOS-RTT_RTT-SCRIPTING_LIBRARY}
-    rtt_dynamic_reconfigure_tests_component
-  )
+  orocos_configure_executable(rtt_dynamic_reconfigure_tests)
+  target_link_libraries(rtt_dynamic_reconfigure_tests rtt_dynamic_reconfigure_tests_component)
 
   orocos_generate_package()
 


### PR DESCRIPTION
We do not know for sure which thread is calling this method/operation, but we can check if the current thread is the same as the thread that will process the update/notify operation. If yes, we clone the underlying OperationCaller implementation and set the caller to the processing engine. In this case RTT <2.9 should always call the operation directly as if it would be a ClientThread operation:
https://github.com/orocos-toolchain/rtt/blob/toolchain-2.8/rtt/base/OperationCallerInterface.hpp#L79

RTT 2.9 and above already checks the caller thread internally and therefore does not require this hack.
