### PR TITLE
rtt_roscomm: set minimum ROS subscriber queue_size to 1

### DIFF
--- a/rtt_roscomm/include/rtt_roscomm/rtt_rostopic_ros_msg_transporter.hpp
+++ b/rtt_roscomm/include/rtt_roscomm/rtt_rostopic_ros_msg_transporter.hpp
@@ -210,9 +210,9 @@ namespace rtt_roscomm {
         log(Debug)<<"Creating ROS subscriber for port "<<port->getName()<<" on topic "<<policy.name_id<<endlog();
       }
       if(topicname.length() > 1 && topicname.at(0) == '~') {
-        ros_sub = ros_node_private.subscribe(policy.name_id.substr(1),policy.size,&RosSubChannelElement::newData,this);
+        ros_sub = ros_node_private.subscribe(policy.name_id.substr(1), policy.size > 0 ? policy.size : 1, &RosSubChannelElement::newData, this); // minimum queue_size 1
       } else {
-        ros_sub = ros_node.subscribe(policy.name_id,policy.size,&RosSubChannelElement::newData,this);
+        ros_sub = ros_node.subscribe(policy.name_id, policy.size > 0 ? policy.size : 1, &RosSubChannelElement::newData, this); // minimum queue_size 1
       }
       this->ref();
     }


### PR DESCRIPTION
Using a default queue size of 0 is dangerous. See http://wiki.ros.org/rospy/Overview/Publishers%20and%20Subscribers#Choosing_a_good_queue_size.

I would like to release this patch together with #67 in ROS indigo, knowing that is has the potential to break existing Orocos applications that somehow rely on roscpp's internal buffering, but actually the behavior is undefined anyway if the RTT internally uses data connections and drops older samples after the ROS spinner passes them from roscpp to RTT.
