### PR TITLE
RosSubChannelElement should be created as a shared_ptr

### DIFF
--- a/rtt_roscomm/include/rtt_roscomm/rtt_rostopic_ros_msg_transporter.hpp
+++ b/rtt_roscomm/include/rtt_roscomm/rtt_rostopic_ros_msg_transporter.hpp
@@ -254,7 +254,7 @@ namespace rtt_roscomm {
       }
       else {
         if (!buf) return base::ChannelElementBase::shared_ptr();
-        tmp = new RosSubChannelElement<T>(port,policy);
+        tmp = base::ChannelElementBase::shared_ptr(new RosSubChannelElement<T>(port,policy));
         tmp->setOutput(buf);
         return tmp;
       }


### PR DESCRIPTION
completely fixes #61 
