### PR TITLE
rtt_rosparam extra operations

### DIFF
--- a/rtt_rosparam/include/rtt_rosparam/rosparam.h
+++ b/rtt_rosparam/include/rtt_rosparam/rosparam.h
@@ -36,7 +36,7 @@ namespace rtt_rosparam {
       setRelative("setRelative"),
       setAbsolute("setAbsolute"),
       setPrivate("setPrivate"),
-      setComponentPrivate("setComponentPrivate")
+      setComponentPrivate("setComponentPrivate"),
       setComponentRelative("setComponentRelative")
     {
       this->addOperationCaller(getAllRelative);

--- a/rtt_rosparam/include/rtt_rosparam/rosparam.h
+++ b/rtt_rosparam/include/rtt_rosparam/rosparam.h
@@ -4,6 +4,64 @@
 #include <rtt/RTT.hpp>
 #include <rtt/Property.hpp>
 
+// #include <Eigen/Dense>
+// #define eigen_matrix_xd Eigen::Matrix<double,Eigen::Dynamic,1>
+// #define eigen_matrix_xf Eigen::Matrix<float,Eigen::Dynamic,1>
+
+#ifndef ADD_ROSPARAM_SERVICE_CONSTRUCTOR
+#define ADD_ROSPARAM_SERVICE_CONSTRUCTOR(return_type_str) \
+  ,get##return_type_str("get"#return_type_str) \
+  ,set##return_type_str("set"#return_type_str) \
+  ,get##return_type_str##Relative ("get"#return_type_str"Relative") \
+  ,set##return_type_str##Relative ("set"#return_type_str"Relative") \
+  ,get##return_type_str##Absolute ("get"#return_type_str"Absolute") \
+  ,set##return_type_str##Absolute ("set"#return_type_str"Absolute") \
+  ,get##return_type_str##Private ("get"#return_type_str"Private") \
+  ,set##return_type_str##Private ("set"#return_type_str"Private") \
+  ,get##return_type_str##ComponentPrivate ("get"#return_type_str"ComponentPrivate") \
+  ,set##return_type_str##ComponentPrivate ("set"#return_type_str"ComponentPrivate") \
+  ,get##return_type_str##ComponentRelative ("get"#return_type_str"ComponentRelative") \
+  ,set##return_type_str##ComponentRelative ("set"#return_type_str"ComponentRelative") \
+  ,get##return_type_str##ComponentAbsolute ("get"#return_type_str"ComponentAbsolute") \
+  ,set##return_type_str##ComponentAbsolute ("set"#return_type_str"ComponentAbsolute")
+#endif
+
+#ifndef ADD_ROSPARAM_OPERATION_CALLER
+#define ADD_ROSPARAM_OPERATION_CALLER(return_type_str) \
+  this->addOperationCaller(get##return_type_str); \
+  this->addOperationCaller(set##return_type_str); \
+  this->addOperationCaller(get##return_type_str##Relative); \
+  this->addOperationCaller(set##return_type_str##Relative); \
+  this->addOperationCaller(get##return_type_str##Absolute); \
+  this->addOperationCaller(set##return_type_str##Absolute); \
+  this->addOperationCaller(get##return_type_str##Private); \
+  this->addOperationCaller(set##return_type_str##Private); \
+  this->addOperationCaller(get##return_type_str##ComponentPrivate); \
+  this->addOperationCaller(set##return_type_str##ComponentPrivate); \
+  this->addOperationCaller(get##return_type_str##ComponentRelative); \
+  this->addOperationCaller(set##return_type_str##ComponentRelative); \
+  this->addOperationCaller(get##return_type_str##ComponentAbsolute); \
+  this->addOperationCaller(set##return_type_str##ComponentAbsolute);
+#endif
+
+#ifndef DECLARE_ROSPARAM_OPERATION_CALLER
+#define DECLARE_ROSPARAM_OPERATION_CALLER(return_type_str, return_type) \
+  RTT::OperationCaller<bool(const std::string &, return_type &)>        get##return_type_str; \
+  RTT::OperationCaller<void(const std::string &, const return_type &)>  set##return_type_str; \
+  RTT::OperationCaller<bool(const std::string &, return_type &)>        get##return_type_str##Relative; \
+  RTT::OperationCaller<void(const std::string &, const return_type &)>  set##return_type_str##Relative; \
+  RTT::OperationCaller<bool(const std::string &, return_type &)>        get##return_type_str##Absolute; \
+  RTT::OperationCaller<void(const std::string &, const return_type &)>  set##return_type_str##Absolute; \
+  RTT::OperationCaller<bool(const std::string &, return_type &)>        get##return_type_str##Private; \
+  RTT::OperationCaller<void(const std::string &, const return_type &)>  set##return_type_str##Private; \
+  RTT::OperationCaller<bool(const std::string &, return_type &)>        get##return_type_str##ComponentPrivate; \
+  RTT::OperationCaller<void(const std::string &, const return_type &)>  set##return_type_str##ComponentPrivate; \
+  RTT::OperationCaller<bool(const std::string &, return_type &)>        get##return_type_str##ComponentRelative; \
+  RTT::OperationCaller<void(const std::string &, const return_type &)>  set##return_type_str##ComponentRelative; \
+  RTT::OperationCaller<bool(const std::string &, return_type &)>        get##return_type_str##ComponentAbsolute; \
+  RTT::OperationCaller<void(const std::string &, const return_type &)>  set##return_type_str##ComponentAbsolute;
+#endif
+
 namespace rtt_rosparam {
 
   class ROSParam : public RTT::ServiceRequester
@@ -37,19 +95,18 @@ namespace rtt_rosparam {
       setAbsolute("setAbsolute"),
       setPrivate("setPrivate"),
       setComponentPrivate("setComponentPrivate"),
-      setComponentRelative("setComponentRelative"),
-      getBool("getBool"),
-      getInt("getInt"),
-      getFloat("getFloat"),
-      getDouble("getDouble"),
-      getVectorOfDouble("getVectorOfDouble"),
-      getVectorOfString("getVectorOfString"),
-      setBool("setBool"),
-      setInt("setInt"),
-      setFloat("setFloat"),
-      setDouble("setDouble"),
-      setVectorOfDouble("setVectorOfDouble"),
-      setVectorOfString("setVectorOfString")
+      setComponentRelative("setComponentRelative")
+      
+      ADD_ROSPARAM_SERVICE_CONSTRUCTOR(String)
+      ADD_ROSPARAM_SERVICE_CONSTRUCTOR(Double)
+      ADD_ROSPARAM_SERVICE_CONSTRUCTOR(Float)
+      ADD_ROSPARAM_SERVICE_CONSTRUCTOR(Int)
+      ADD_ROSPARAM_SERVICE_CONSTRUCTOR(Bool)
+      ADD_ROSPARAM_SERVICE_CONSTRUCTOR(VectorOfString)
+      ADD_ROSPARAM_SERVICE_CONSTRUCTOR(VectorOfDouble)
+    //   ADD_ROSPARAM_SERVICE_CONSTRUCTOR(EigenVectorXd)
+    //   ADD_ROSPARAM_SERVICE_CONSTRUCTOR(EigenVectorXf)
+      
     {
       this->addOperationCaller(getAllRelative);
       this->addOperationCaller(getAllAbsolute);
@@ -81,19 +138,15 @@ namespace rtt_rosparam {
       this->addOperationCaller(setComponentPrivate);
       this->addOperationCaller(setComponentRelative);
 
-      this->addOperationCaller(getBool);
-      this->addOperationCaller(getInt);
-      this->addOperationCaller(getFloat);
-      this->addOperationCaller(getDouble);
-      this->addOperationCaller(getVectorOfDouble);
-      this->addOperationCaller(getVectorOfString);
-
-      this->addOperationCaller(setBool);
-      this->addOperationCaller(setInt);
-      this->addOperationCaller(setFloat);
-      this->addOperationCaller(setDouble);
-      this->addOperationCaller(setVectorOfDouble);
-      this->addOperationCaller(setVectorOfString);
+      ADD_ROSPARAM_OPERATION_CALLER(String)
+      ADD_ROSPARAM_OPERATION_CALLER(Double)
+      ADD_ROSPARAM_OPERATION_CALLER(Float)
+      ADD_ROSPARAM_OPERATION_CALLER(Int)
+      ADD_ROSPARAM_OPERATION_CALLER(Bool)
+      ADD_ROSPARAM_OPERATION_CALLER(VectorOfString)
+      ADD_ROSPARAM_OPERATION_CALLER(VectorOfDouble)
+    //   ADD_ROSPARAM_OPERATION_CALLER(EigenVectorXd)
+    //   ADD_ROSPARAM_OPERATION_CALLER(EigenVectorXf)
     }
 
     typedef enum  {
@@ -133,20 +186,17 @@ namespace rtt_rosparam {
     RTT::OperationCaller<bool(const std::string &)> setPrivate;
     RTT::OperationCaller<bool(const std::string &)> setComponentPrivate;
     RTT::OperationCaller<bool(const std::string &)> setComponentRelative;
-
-    RTT::OperationCaller<bool(const std::string &, bool &)> getBool;
-    RTT::OperationCaller<bool(const std::string &, int &)> getInt;
-    RTT::OperationCaller<bool(const std::string &, float &)> getFloat;
-    RTT::OperationCaller<bool(const std::string &, double &)> getDouble;
-    RTT::OperationCaller<bool(const std::string &, std::vector<double> &)> getVectorOfDouble;
-    RTT::OperationCaller<bool(const std::string &, std::vector<std::string> &)> getVectorOfString;
-
-    RTT::OperationCaller<void(const bool&)> setBool;
-    RTT::OperationCaller<void(const int&)> setInt;
-    RTT::OperationCaller<void(const float&)> setFloat;
-    RTT::OperationCaller<void(const double&)> setDouble;
-    RTT::OperationCaller<void(const std::vector<double> &)> setVectorOfDouble;
-    RTT::OperationCaller<void(const std::vector<std::string> &)> setVectorOfString;
+    
+    DECLARE_ROSPARAM_OPERATION_CALLER(String, std::string)
+    DECLARE_ROSPARAM_OPERATION_CALLER(Double, double)
+    DECLARE_ROSPARAM_OPERATION_CALLER(Float, float)
+    DECLARE_ROSPARAM_OPERATION_CALLER(Int, int)
+    DECLARE_ROSPARAM_OPERATION_CALLER(Bool, bool)
+    DECLARE_ROSPARAM_OPERATION_CALLER(VectorOfString, std::vector<std::string>)
+    DECLARE_ROSPARAM_OPERATION_CALLER(VectorOfDouble, std::vector<double>)
+    // DECLARE_ROSPARAM_OPERATION_CALLER(EigenVectorXd, eigen_matrix_xd)
+    // DECLARE_ROSPARAM_OPERATION_CALLER(EigenVectorXf, eigen_matrix_xf)
+    
   };
 }
 

--- a/rtt_rosparam/include/rtt_rosparam/rosparam.h
+++ b/rtt_rosparam/include/rtt_rosparam/rosparam.h
@@ -37,7 +37,19 @@ namespace rtt_rosparam {
       setAbsolute("setAbsolute"),
       setPrivate("setPrivate"),
       setComponentPrivate("setComponentPrivate"),
-      setComponentRelative("setComponentRelative")
+      setComponentRelative("setComponentRelative"),
+      getBool("getBool"),
+      getInt("getInt"),
+      getFloat("getFloat"),
+      getDouble("getDouble"),
+      getVectorOfDouble("getVectorOfDouble"),
+      getVectorOfString("getVectorOfString"),
+      setBool("setBool"),
+      setInt("setInt"),
+      setFloat("setFloat"),
+      setDouble("setDouble"),
+      setVectorOfDouble("setVectorOfDouble"),
+      setVectorOfString("setVectorOfString")
     {
       this->addOperationCaller(getAllRelative);
       this->addOperationCaller(getAllAbsolute);
@@ -68,6 +80,20 @@ namespace rtt_rosparam {
       this->addOperationCaller(setPrivate);
       this->addOperationCaller(setComponentPrivate);
       this->addOperationCaller(setComponentRelative);
+
+      this->addOperationCaller(getBool);
+      this->addOperationCaller(getInt);
+      this->addOperationCaller(getFloat);
+      this->addOperationCaller(getDouble);
+      this->addOperationCaller(getVectorOfDouble);
+      this->addOperationCaller(getVectorOfString);
+
+      this->addOperationCaller(setBool);
+      this->addOperationCaller(setInt);
+      this->addOperationCaller(setFloat);
+      this->addOperationCaller(setDouble);
+      this->addOperationCaller(setVectorOfDouble);
+      this->addOperationCaller(setVectorOfString);
     }
 
     typedef enum  {
@@ -75,7 +101,8 @@ namespace rtt_rosparam {
       ABSOLUTE, //! Absolute resolution:  "name" -> "/name"
       PRIVATE,  //! Private resolution:   "name" -> "~name"
       COMPONENT_PRIVATE, //! Component resolution: "name" -> "~COMPONENT_NAME/name"
-      COMPONENT_RELATIVE //! Component resolution: "name" -> "COMPONENT_NAME/name"
+      COMPONENT_RELATIVE, //! Component resolution: "name" -> "COMPONENT_NAME/name"
+      COMPONENT = COMPONENT_PRIVATE //! For backwards compatibility, component resolution: COMPONENT_PRIVATE
     }ResolutionPolicy;
 
     RTT::OperationCaller<bool(void)> getAllRelative;
@@ -106,6 +133,20 @@ namespace rtt_rosparam {
     RTT::OperationCaller<bool(const std::string &)> setPrivate;
     RTT::OperationCaller<bool(const std::string &)> setComponentPrivate;
     RTT::OperationCaller<bool(const std::string &)> setComponentRelative;
+
+    RTT::OperationCaller<bool(const std::string &, bool &)> getBool;
+    RTT::OperationCaller<bool(const std::string &, int &)> getInt;
+    RTT::OperationCaller<bool(const std::string &, float &)> getFloat;
+    RTT::OperationCaller<bool(const std::string &, double &)> getDouble;
+    RTT::OperationCaller<bool(const std::string &, std::vector<double> &)> getVectorOfDouble;
+    RTT::OperationCaller<bool(const std::string &, std::vector<std::string> &)> getVectorOfString;
+
+    RTT::OperationCaller<void(const bool&)> setBool;
+    RTT::OperationCaller<void(const int&)> setInt;
+    RTT::OperationCaller<void(const float&)> setFloat;
+    RTT::OperationCaller<void(const double&)> setDouble;
+    RTT::OperationCaller<void(const std::vector<double> &)> setVectorOfDouble;
+    RTT::OperationCaller<void(const std::vector<std::string> &)> setVectorOfString;
   };
 }
 

--- a/rtt_rosparam/include/rtt_rosparam/rosparam.h
+++ b/rtt_rosparam/include/rtt_rosparam/rosparam.h
@@ -16,11 +16,13 @@ namespace rtt_rosparam {
       getAllAbsolute("getAllAbsolute"),
       getAllPrivate("getAllPrivate"),
       getAllComponentPrivate("getAllComponentPrivate"),
+      getAllComponentRelative("getAllComponentRelative"),
       getAll("getAll"),
       setAllRelative("setAllRelative"),
       setAllAbsolute("setAllAbsolute"),
       setAllPrivate("setAllPrivate"),
       setAllComponentPrivate("setAllComponentPrivate"),
+      setAllComponentRelative("setAllComponentRelative"),
       setAll("setAll"),
       get("get"),
       getParam("getParam"),
@@ -28,23 +30,27 @@ namespace rtt_rosparam {
       getAbsolute("getAbsolute"),
       getPrivate("getPrivate"),
       getComponentPrivate("getComponentPrivate"),
+      getComponentRelative("getComponentRelative"),
       set("set"),
       setParam("setParam"),
       setRelative("setRelative"),
       setAbsolute("setAbsolute"),
       setPrivate("setPrivate"),
       setComponentPrivate("setComponentPrivate")
+      setComponentRelative("setComponentRelative")
     {
       this->addOperationCaller(getAllRelative);
       this->addOperationCaller(getAllAbsolute);
       this->addOperationCaller(getAllPrivate);
       this->addOperationCaller(getAllComponentPrivate);
+      this->addOperationCaller(getAllComponentRelative);
       this->addOperationCaller(getAll);
 
       this->addOperationCaller(setAllRelative);
       this->addOperationCaller(setAllAbsolute);
       this->addOperationCaller(setAllPrivate);
       this->addOperationCaller(setAllComponentPrivate);
+      this->addOperationCaller(setAllComponentRelative);
       this->addOperationCaller(setAll);
 
       this->addOperationCaller(get);
@@ -53,6 +59,7 @@ namespace rtt_rosparam {
       this->addOperationCaller(getAbsolute);
       this->addOperationCaller(getPrivate);
       this->addOperationCaller(getComponentPrivate);
+      this->addOperationCaller(getComponentRelative);
 
       this->addOperationCaller(set);
       this->addOperationCaller(setParam);
@@ -60,24 +67,28 @@ namespace rtt_rosparam {
       this->addOperationCaller(setAbsolute);
       this->addOperationCaller(setPrivate);
       this->addOperationCaller(setComponentPrivate);
+      this->addOperationCaller(setComponentRelative);
     }
 
     typedef enum  {
       RELATIVE, //! Relative resolution:  "name" -> "name"
       ABSOLUTE, //! Absolute resolution:  "name" -> "/name"
       PRIVATE,  //! Private resolution:   "name" -> "~name"
-      COMPONENT //! Component resolution: "name" -> "~COMPONENT_NAME/name"
+      COMPONENT_PRIVATE, //! Component resolution: "name" -> "~COMPONENT_NAME/name"
+      COMPONENT_RELATIVE //! Component resolution: "name" -> "COMPONENT_NAME/name"
     }ResolutionPolicy;
 
     RTT::OperationCaller<bool(void)> getAllRelative;
     RTT::OperationCaller<bool(void)> getAllAbsolute;
     RTT::OperationCaller<bool(void)> getAllPrivate;
     RTT::OperationCaller<bool(void)> getAllComponentPrivate;
+    RTT::OperationCaller<bool(void)> getAllComponentRelative;
     RTT::OperationCaller<bool(void)> getAll;
     RTT::OperationCaller<bool(void)> setAllRelative;
     RTT::OperationCaller<bool(void)> setAllAbsolute;
     RTT::OperationCaller<bool(void)> setAllPrivate;
     RTT::OperationCaller<bool(void)> setAllComponentPrivate;
+    RTT::OperationCaller<bool(void)> setAllComponentRelative;
     RTT::OperationCaller<bool(void)> setAll;
 
     RTT::OperationCaller<bool(const std::string &, const unsigned int)> get;
@@ -86,6 +97,7 @@ namespace rtt_rosparam {
     RTT::OperationCaller<bool(const std::string &)> getAbsolute;
     RTT::OperationCaller<bool(const std::string &)> getPrivate;
     RTT::OperationCaller<bool(const std::string &)> getComponentPrivate;
+    RTT::OperationCaller<bool(const std::string &)> getComponentRelative;
 
     RTT::OperationCaller<bool(const std::string &, const unsigned int)> set;
     RTT::OperationCaller<bool(const std::string &, const std::string &)> setParam;
@@ -93,6 +105,7 @@ namespace rtt_rosparam {
     RTT::OperationCaller<bool(const std::string &)> setAbsolute;
     RTT::OperationCaller<bool(const std::string &)> setPrivate;
     RTT::OperationCaller<bool(const std::string &)> setComponentPrivate;
+    RTT::OperationCaller<bool(const std::string &)> setComponentRelative;
   };
 }
 

--- a/rtt_rosparam/src/rtt_rosparam_service.cpp
+++ b/rtt_rosparam/src/rtt_rosparam_service.cpp
@@ -13,21 +13,21 @@
 #include <ros/ros.h>
 
 #ifndef ADD_ROSPARAM_OPERATION
-#define ADD_ROSPARAM_OPERATION(return_type_str, return_type) \
-  this->addOperation("get"#return_type_str, &ROSParamService::getParamImpl< return_type , RELATIVE >, this).doc("Get a " #return_type " from rosparam"); \
-  this->addOperation("set"#return_type_str, &ROSParamService::setParamImpl< return_type , RELATIVE >, this).doc("Set a " #return_type " in rosparam"); \
-  this->addOperation("get"#return_type_str"Relative", &ROSParamService::getParamImpl< return_type , RELATIVE >, this).doc("Get a " #return_type " from rosparam using the relative resolution policy : `relative/param`"); \
-  this->addOperation("set"#return_type_str"Relative", &ROSParamService::setParamImpl< return_type , RELATIVE >, this).doc("Set a " #return_type " in rosparam using the relative resolution policy : `relative/param`"); \
-  this->addOperation("get"#return_type_str"Absolute", &ROSParamService::getParamImpl< return_type , ABSOLUTE >, this).doc("Get a " #return_type " from rosparam using the absolute resolution policy : `/global/param`"); \
-  this->addOperation("set"#return_type_str"Absolute", &ROSParamService::setParamImpl< return_type , ABSOLUTE >, this).doc("Set a " #return_type " in rosparam using the absolute resolution policy : `/global/param`"); \
-  this->addOperation("get"#return_type_str"Private", &ROSParamService::getParamImpl< return_type , PRIVATE >, this).doc("Get a " #return_type " from rosparam using the private resolution policy : `~private/param`"); \
-  this->addOperation("set"#return_type_str"Private", &ROSParamService::setParamImpl< return_type , PRIVATE >, this).doc("Set a " #return_type " in rosparam using the private resolution policy : `~private/param`"); \
-  this->addOperation("get"#return_type_str"ComponentPrivate", &ROSParamService::getParamImpl< return_type , COMPONENT_PRIVATE >, this).doc("Get a " #return_type " from rosparam using the following resolution policy : `~component_name/param`"); \
-  this->addOperation("set"#return_type_str"ComponentPrivate", &ROSParamService::setParamImpl< return_type , COMPONENT_PRIVATE >, this).doc("Set a " #return_type " in rosparam using the following resolution policy : `~component_name/param`"); \
-  this->addOperation("get"#return_type_str"ComponentRelative", &ROSParamService::getParamImpl< return_type , COMPONENT_RELATIVE >, this).doc("Get a " #return_type " from rosparam using the following resolution policy : `component_name/param`"); \
-  this->addOperation("set"#return_type_str"ComponentRelative", &ROSParamService::setParamImpl< return_type , COMPONENT_RELATIVE >, this).doc("Set a " #return_type " in rosparam using the following resolution policy : `component_name/param`"); \
-  this->addOperation("get"#return_type_str"ComponentAbsolute", &ROSParamService::getParamImpl< return_type , COMPONENT_ABSOLUTE >, this).doc("Get a " #return_type " from rosparam using the following resolution policy : `/component_name/param`"); \
-  this->addOperation("set"#return_type_str"ComponentAbsolute", &ROSParamService::setParamImpl< return_type , COMPONENT_ABSOLUTE >, this).doc("Set a " #return_type " in rosparam using the following resolution policy : `/component_name/param`");
+#define ADD_ROSPARAM_OPERATION(return_type_str, return_type, func) \
+  this->addOperation("get"#return_type_str, &ROSParamService::get##func< return_type , RELATIVE >, this).doc("Get a " #return_type " from rosparam"); \
+  this->addOperation("set"#return_type_str, &ROSParamService::set##func< return_type , RELATIVE >, this).doc("Set a " #return_type " in rosparam"); \
+  this->addOperation("get"#return_type_str"Relative", &ROSParamService::get##func< return_type , RELATIVE >, this).doc("Get a " #return_type " from rosparam using the relative resolution policy : `relative/param`"); \
+  this->addOperation("set"#return_type_str"Relative", &ROSParamService::set##func< return_type , RELATIVE >, this).doc("Set a " #return_type " in rosparam using the relative resolution policy : `relative/param`"); \
+  this->addOperation("get"#return_type_str"Absolute", &ROSParamService::get##func< return_type , ABSOLUTE >, this).doc("Get a " #return_type " from rosparam using the absolute resolution policy : `/global/param`"); \
+  this->addOperation("set"#return_type_str"Absolute", &ROSParamService::set##func< return_type , ABSOLUTE >, this).doc("Set a " #return_type " in rosparam using the absolute resolution policy : `/global/param`"); \
+  this->addOperation("get"#return_type_str"Private", &ROSParamService::get##func< return_type , PRIVATE >, this).doc("Get a " #return_type " from rosparam using the private resolution policy : `~private/param`"); \
+  this->addOperation("set"#return_type_str"Private", &ROSParamService::set##func< return_type , PRIVATE >, this).doc("Set a " #return_type " in rosparam using the private resolution policy : `~private/param`"); \
+  this->addOperation("get"#return_type_str"ComponentPrivate", &ROSParamService::get##func< return_type , COMPONENT_PRIVATE >, this).doc("Get a " #return_type " from rosparam using the following resolution policy : `~component_name/param`"); \
+  this->addOperation("set"#return_type_str"ComponentPrivate", &ROSParamService::set##func< return_type , COMPONENT_PRIVATE >, this).doc("Set a " #return_type " in rosparam using the following resolution policy : `~component_name/param`"); \
+  this->addOperation("get"#return_type_str"ComponentRelative", &ROSParamService::get##func< return_type , COMPONENT_RELATIVE >, this).doc("Get a " #return_type " from rosparam using the following resolution policy : `component_name/param`"); \
+  this->addOperation("set"#return_type_str"ComponentRelative", &ROSParamService::set##func< return_type , COMPONENT_RELATIVE >, this).doc("Set a " #return_type " in rosparam using the following resolution policy : `component_name/param`"); \
+  this->addOperation("get"#return_type_str"ComponentAbsolute", &ROSParamService::get##func< return_type , COMPONENT_ABSOLUTE >, this).doc("Get a " #return_type " from rosparam using the following resolution policy : `/component_name/param`"); \
+  this->addOperation("set"#return_type_str"ComponentAbsolute", &ROSParamService::set##func< return_type , COMPONENT_ABSOLUTE >, this).doc("Set a " #return_type " in rosparam using the following resolution policy : `/component_name/param`");
 #endif
 
 
@@ -129,15 +129,18 @@ public:
       .doc("Sets one parameter on the ROS param server from the similarly-named property of this component (or stores the properties of a named RTT sub-service) in the component's private namespace.")
       .arg("name", "Name of the property / service / parameter.");
 
-    ADD_ROSPARAM_OPERATION(String, std::string)
-    ADD_ROSPARAM_OPERATION(Double, double)
-    ADD_ROSPARAM_OPERATION(Float, float)
-    ADD_ROSPARAM_OPERATION(Int, int)
-    ADD_ROSPARAM_OPERATION(Bool, bool)
+    ADD_ROSPARAM_OPERATION(String, std::string, ParamImpl)
+    ADD_ROSPARAM_OPERATION(Double, double, ParamImpl)
+    ADD_ROSPARAM_OPERATION(Float, float, ParamImpl)
+    ADD_ROSPARAM_OPERATION(Int, int, ParamImpl)
+    ADD_ROSPARAM_OPERATION(Bool, bool, ParamImpl)
 
     // Vector parameters
-    ADD_ROSPARAM_OPERATION(VectorOfString, std::vector<std::string>)
-    ADD_ROSPARAM_OPERATION(VectorOfDouble, std::vector<double>)
+    ADD_ROSPARAM_OPERATION(VectorOfString, std::vector<std::string>, ParamImpl)
+    ADD_ROSPARAM_OPERATION(VectorOfDouble, std::vector<double>, ParamImpl)
+
+    ADD_ROSPARAM_OPERATION(EigenVectorXd, double, EigenVectorParamImpl)
+    ADD_ROSPARAM_OPERATION(EigenVectorXf, float, EigenVectorParamImpl)
 
   }
 private:
@@ -154,6 +157,22 @@ private:
   template <typename T, ROSParamService::ResolutionPolicy P> void setParamImpl(const std::string& ros_param_name, const T& value)
   {
     ros::param::set(resolvedName(ros_param_name,P), value);
+  }
+
+  template <typename T, ROSParamService::ResolutionPolicy P> bool getEigenVectorParamImpl(const std::string& ros_param_name, Eigen::Matrix<T,Eigen::Dynamic,1>& eigen_vector)
+  {
+    std::vector<T> value;
+    if (!getParamImpl< std::vector<T> , P >(ros_param_name,value)) {
+      return false;
+    }
+    eigen_vector = Eigen::Matrix<T,Eigen::Dynamic,1>::Map(value.data(),value.size());
+    return true;
+  }
+
+  template <typename T, ROSParamService::ResolutionPolicy P> void setEigenVectorParamImpl(const std::string& ros_param_name, const Eigen::Matrix<T,Eigen::Dynamic,1>& eigen_vector)
+  {
+    std::vector<T> value(eigen_vector.data(),eigen_vector.data() + eigen_vector.size() );
+    setParamImpl< std::vector<T> , P >(ros_param_name,value);
   }
 
   //! Resolve a parameter name based on the given \ref ResolutionPolicy

--- a/rtt_rosparam/src/rtt_rosparam_service.cpp
+++ b/rtt_rosparam/src/rtt_rosparam_service.cpp
@@ -12,6 +12,29 @@
 
 #include <ros/ros.h>
 
+#ifndef DECLARE_ROSPARAM_GETTER_SETTER
+#define DECLARE_ROSPARAM_GETTER_SETTER(function_name,return_type) \
+bool get##function_name(const std::string& ros_param_name,return_type& ret) \
+{ \
+    if(!ros::param::get(ros_param_name,ret)){ \
+        RTT::log(RTT::Debug) << "ROS Parameter \"" << ros_param_name << "\" not found on the parameter server!" << RTT::endlog(); \
+        return false; \
+    } \
+    return true; \
+} \
+void set##function_name(const std::string& ros_param_name,const return_type& ret) \
+{ \
+    ros::param::set(ros_param_name,ret); \
+}
+#endif
+
+#ifndef DECLARE_ROSPARAM_OPERATION
+#define DECLARE_ROSPARAM_OPERATION(function_name) \
+this->addOperation("get"#function_name,&ROSParamService::get##function_name,this).doc("Get a "#function_name" from ros parameter server");\
+this->addOperation("set"#function_name,&ROSParamService::set##function_name,this).doc("Set a "#function_name" in the ros parameter server");
+#endif
+
+
 using namespace RTT;
 using namespace std;
 
@@ -106,8 +129,30 @@ public:
       .doc("Sets one parameter on the ROS param server from the similarly-named property of this component (or stores the properties of a named RTT sub-service) in the component's private namespace.")
       .arg("name", "Name of the property / service / parameter.");
 
+    DECLARE_ROSPARAM_OPERATION(String)
+    DECLARE_ROSPARAM_OPERATION(Double)
+    DECLARE_ROSPARAM_OPERATION(Int)
+    DECLARE_ROSPARAM_OPERATION(Bool)
+
+    // Vector parameters
+    DECLARE_ROSPARAM_OPERATION(VectorOfString)
+    DECLARE_ROSPARAM_OPERATION(VectorOfDouble)
+    DECLARE_ROSPARAM_OPERATION(VectorOfInt)
+    DECLARE_ROSPARAM_OPERATION(VectorOfBool)
+
   }
 private:
+
+  DECLARE_ROSPARAM_GETTER_SETTER(String,std::string)
+  DECLARE_ROSPARAM_GETTER_SETTER(Double,double)
+  DECLARE_ROSPARAM_GETTER_SETTER(Int,int)
+  DECLARE_ROSPARAM_GETTER_SETTER(Bool,bool)
+
+    // Vector parameters
+  DECLARE_ROSPARAM_GETTER_SETTER(VectorOfString,std::vector<std::string>)
+  DECLARE_ROSPARAM_GETTER_SETTER(VectorOfDouble,std::vector<double>)
+  DECLARE_ROSPARAM_GETTER_SETTER(VectorOfInt,std::vector<int>)
+  DECLARE_ROSPARAM_GETTER_SETTER(VectorOfBool,std::vector<bool>)
 
   //! Resolve a parameter name based on the given \ref ResolutionPolicy
   const std::string resolvedName(

--- a/rtt_rosparam/src/rtt_rosparam_service.cpp
+++ b/rtt_rosparam/src/rtt_rosparam_service.cpp
@@ -131,28 +131,26 @@ public:
 
     DECLARE_ROSPARAM_OPERATION(String)
     DECLARE_ROSPARAM_OPERATION(Double)
+    DECLARE_ROSPARAM_OPERATION(Float)
     DECLARE_ROSPARAM_OPERATION(Int)
     DECLARE_ROSPARAM_OPERATION(Bool)
 
     // Vector parameters
     DECLARE_ROSPARAM_OPERATION(VectorOfString)
     DECLARE_ROSPARAM_OPERATION(VectorOfDouble)
-    DECLARE_ROSPARAM_OPERATION(VectorOfInt)
-    DECLARE_ROSPARAM_OPERATION(VectorOfBool)
 
   }
 private:
 
   DECLARE_ROSPARAM_GETTER_SETTER(String,std::string)
   DECLARE_ROSPARAM_GETTER_SETTER(Double,double)
+  DECLARE_ROSPARAM_GETTER_SETTER(Float,float)
   DECLARE_ROSPARAM_GETTER_SETTER(Int,int)
   DECLARE_ROSPARAM_GETTER_SETTER(Bool,bool)
 
     // Vector parameters
   DECLARE_ROSPARAM_GETTER_SETTER(VectorOfString,std::vector<std::string>)
   DECLARE_ROSPARAM_GETTER_SETTER(VectorOfDouble,std::vector<double>)
-  DECLARE_ROSPARAM_GETTER_SETTER(VectorOfInt,std::vector<int>)
-  DECLARE_ROSPARAM_GETTER_SETTER(VectorOfBool,std::vector<bool>)
 
   //! Resolve a parameter name based on the given \ref ResolutionPolicy
   const std::string resolvedName(

--- a/rtt_rosparam/src/rtt_rosparam_service.cpp
+++ b/rtt_rosparam/src/rtt_rosparam_service.cpp
@@ -23,7 +23,8 @@ public:
     RELATIVE, //! Relative resolution:  "name" -> "name"
     ABSOLUTE, //! Absolute resolution:  "name" -> "/name"
     PRIVATE,  //! Private resolution:   "name" -> "~name"
-    COMPONENT //! Component resolution: "name" -> "~COMPONENT_NAME/name"
+    COMPONENT_PRIVATE, //! Component resolution: "name" -> "~COMPONENT_PRIVATE_NAME/name"
+    COMPONENT_RELATIVE //! Component resolution: "name" -> "COMPONENT_RELATIVE_NAME/name"
   }ResolutionPolicy;
 
   ROSParamService(TaskContext* owner) :
@@ -34,7 +35,8 @@ public:
     this->addConstant("RELATIVE",static_cast<int>(RELATIVE));
     this->addConstant("ABSOLUTE",static_cast<int>(ABSOLUTE));
     this->addConstant("PRIVATE",static_cast<int>(PRIVATE));
-    this->addConstant("COMPONENT",static_cast<int>(COMPONENT));
+    this->addConstant("COMPONENT_PRIVATE",static_cast<int>(COMPONENT_PRIVATE));
+    this->addConstant("COMPONENT_RELATIVE",static_cast<int>(COMPONENT_RELATIVE));
 
     this->addOperation("getAllRelative", &ROSParamService::getParamsRelative, this)
       .doc("Gets all properties of this component (and its sub-services) from the ROS param server in the relative namespace.");
@@ -44,6 +46,8 @@ public:
       .doc("Gets all properties of this component (and its sub-services) from the ROS param server in the node's private namespace.");
     this->addOperation("getAllComponentPrivate", &ROSParamService::getParamsComponentPrivate, this)
       .doc("Gets all properties of this component (and its sub-services) from the ROS param server in the component's private namespace.");
+    this->addOperation("getAllComponentRelative", &ROSParamService::getParamsComponentRelative, this)
+      .doc("Gets all properties of this component (and its sub-services) from the ROS param server in the component's relative namespace.");
     this->addOperation("getAll", &ROSParamService::getParamsComponentPrivate, this)
       .doc("Gets all properties of this component (and its sub-services) from the ROS param server in the component's private namespace. This is an alias for getAllComponentPrivate().");
 
@@ -58,56 +62,56 @@ public:
     this->addOperation("setAll", &ROSParamService::setParamsComponentPrivate, this)
       .doc("Stores all properties of this component (and its sub-services) on the ROS param server from the similarly-named property in the component's private namespace. This is an alias for setAllComponentPrivate().");
 
-    this->addOperation("get", &ROSParamService::get, this) 
+    this->addOperation("get", &ROSParamService::get, this)
       .doc("Gets one property of this component (or populates the properties of a named RTT sub-service) from the ROS param server based on the given resolution policy.")
       .arg("name", "Name of the property / service / parameter.")
       .arg("policy", "ROS parameter namespace resolution policy.");
-    this->addOperation("getParam", &ROSParamService::getParam, this) 
+    this->addOperation("getParam", &ROSParamService::getParam, this)
       .doc("Gets one property of this component (or populates the properties of a named RTT sub-service) from the ROS param server based on the given ROS parameter name.")
       .arg("param_name", "Name of the ROS parameter. Use '~' and '/' leaders for private or absolute resolution.")
       .arg("name", "Name of the RTT property or service.");
 
-    this->addOperation("getRelative", &ROSParamService::getParamRelative, this) 
+    this->addOperation("getRelative", &ROSParamService::getParamRelative, this)
       .doc("Gets one property of this component (or populates the properties of a named RTT sub-service) from the ROS param server in the relative namespace.")
       .arg("name", "Name of the property / service / parameter.");
-    this->addOperation("getAbsolute", &ROSParamService::getParamAbsolute, this) 
+    this->addOperation("getAbsolute", &ROSParamService::getParamAbsolute, this)
       .doc("Gets one property of this component (or populates the properties of a named RTT sub-service) from the ROS param server in the absolute namespace.")
       .arg("name", "Name of the property / service / parameter.");
-    this->addOperation("getPrivate", &ROSParamService::getParamPrivate, this) 
+    this->addOperation("getPrivate", &ROSParamService::getParamPrivate, this)
       .doc("Gets one property of this component (or populates the properties of a named RTT sub-service) from the ROS param server in the node's private namespace.")
       .arg("name", "Name of the property / service / parameter.");
-    this->addOperation("getComponentPrivate", &ROSParamService::getParamComponentPrivate, this) 
+    this->addOperation("getComponentPrivate", &ROSParamService::getParamComponentPrivate, this)
       .doc("Gets one property of this component (or populates the properties of a named RTT sub-service) from the ROS param server in the component's private namespace.")
       .arg("name", "Name of the property / service / parameter.");
 
-    this->addOperation("set", &ROSParamService::set, this) 
+    this->addOperation("set", &ROSParamService::set, this)
       .doc("Sets one parameter on the ROS param server from the similarly-named property of this component (or stores the properties of a named RTT sub-service) in the ROS parameter namespace based on the given resolution policy.")
       .arg("name", "Name of the property / service / parameter.")
       .arg("policy", "ROS parameter namespace resolution policy.");
-    this->addOperation("setParam", &ROSParamService::setParam, this) 
+    this->addOperation("setParam", &ROSParamService::setParam, this)
       .doc("Sets one parameter on the ROS param server from the similarly-named property of this component (or stores the properties of a named RTT sub-service) in the ROS parameter namespace based on the given ROS parameter name.")
       .arg("param_name", "Name of the ROS parameter. Use '~' and '/' leaders for private or absolute resolution.")
       .arg("name", "Name of the RTT property or service.");
 
-    this->addOperation("setRelative", &ROSParamService::setParamRelative, this) 
+    this->addOperation("setRelative", &ROSParamService::setParamRelative, this)
       .doc("Sets one parameter on the ROS param server from the similarly-named property of this component (or stores the properties of a named RTT sub-service) in the relative namespace.")
       .arg("name", "Name of the property / service / parameter.");
-    this->addOperation("setAbsolute", &ROSParamService::setParamAbsolute, this) 
+    this->addOperation("setAbsolute", &ROSParamService::setParamAbsolute, this)
       .doc("Sets one parameter on the ROS param server from the similarly-named property of this component (or stores the properties of a named RTT sub-service) in the absolute namespace.")
       .arg("name", "Name of the property / service / parameter.");
-    this->addOperation("setPrivate", &ROSParamService::setParamPrivate, this) 
+    this->addOperation("setPrivate", &ROSParamService::setParamPrivate, this)
       .doc("Sets one parameter on the ROS param server from the similarly-named property of this component (or stores the properties of a named RTT sub-service) in the node's private namespace.")
       .arg("name", "Name of the property / service / parameter.");
-    this->addOperation("setComponentPrivate", &ROSParamService::setParamComponentPrivate, this) 
+    this->addOperation("setComponentPrivate", &ROSParamService::setParamComponentPrivate, this)
       .doc("Sets one parameter on the ROS param server from the similarly-named property of this component (or stores the properties of a named RTT sub-service) in the component's private namespace.")
       .arg("name", "Name of the property / service / parameter.");
-  
+
   }
 private:
 
   //! Resolve a parameter name based on the given \ref ResolutionPolicy
   const std::string resolvedName(
-    const std::string &param_name, 
+    const std::string &param_name,
     const ROSParamService::ResolutionPolicy policy);
 
   bool getParams(RTT::Service::shared_ptr service, const std::string& ns);
@@ -115,40 +119,44 @@ private:
   bool getParamsRelative() { return getParams(RELATIVE); }
   bool getParamsAbsolute() { return getParams(ABSOLUTE); }
   bool getParamsPrivate() { return getParams(PRIVATE); }
-  bool getParamsComponentPrivate() { return getParams(COMPONENT); }
+  bool getParamsComponentPrivate() { return getParams(COMPONENT_PRIVATE); }
+  bool getParamsComponentRelative() { return getParams(COMPONENT_RELATIVE); }
 
   bool get(
-    const std::string &param_name, 
-    const unsigned int policy = (unsigned int)ROSParamService::COMPONENT);
+    const std::string &param_name,
+    const unsigned int policy = (unsigned int)ROSParamService::COMPONENT_PRIVATE);
   bool getParam(
-    const std::string &ros_name, 
+    const std::string &ros_name,
     const std::string &rtt_name);
   bool getParamRelative(const std::string &name) { return get(name, RELATIVE); }
   bool getParamAbsolute(const std::string &name) { return get(name, ABSOLUTE); }
   bool getParamPrivate(const std::string &name) { return get(name, PRIVATE); }
-  bool getParamComponentPrivate(const std::string &name) { return get(name, COMPONENT); }
+  bool getParamComponentPrivate(const std::string &name) { return get(name, COMPONENT_PRIVATE); }
+  bool getParamComponentRelative(const std::string &name) { return get(name, COMPONENT_RELATIVE); }
 
   bool setParams(RTT::Service::shared_ptr service, const std::string& ns);
   bool setParams(const ROSParamService::ResolutionPolicy policy);
   bool setParamsRelative() { return setParams(RELATIVE); }
   bool setParamsAbsolute() { return setParams(ABSOLUTE); }
   bool setParamsPrivate() { return setParams(PRIVATE); }
-  bool setParamsComponentPrivate() { return setParams(COMPONENT); }
+  bool setParamsComponentPrivate() { return setParams(COMPONENT_PRIVATE); }
+  bool setParamsComponentRelative() { return setParams(COMPONENT_RELATIVE); }
 
   bool set(
-    const std::string &param_name, 
-    const unsigned int policy = (unsigned int)ROSParamService::COMPONENT);
+    const std::string &param_name,
+    const unsigned int policy = (unsigned int)ROSParamService::COMPONENT_PRIVATE);
   bool setParam(
-    const std::string &ros_name, 
+    const std::string &ros_name,
     const std::string &rtt_name);
   bool setParamRelative(const std::string &name) { return set(name, RELATIVE); }
   bool setParamAbsolute(const std::string &name) { return set(name, ABSOLUTE); }
   bool setParamPrivate(const std::string &name) { return set(name, PRIVATE); }
-  bool setParamComponentPrivate(const std::string &name) { return set(name, COMPONENT); }
+  bool setParamComponentPrivate(const std::string &name) { return set(name, COMPONENT_PRIVATE); }
+  bool setParamComponentRelative(const std::string &name) { return set(name, COMPONENT_RELATIVE); }
 };
 
 const std::string ROSParamService::resolvedName(
-    const std::string &param_name, 
+    const std::string &param_name,
     const ROSParamService::ResolutionPolicy policy)
 {
   std::string leader = "";
@@ -168,8 +176,11 @@ const std::string ROSParamService::resolvedName(
     case ROSParamService::PRIVATE:
       resolved_name = (leader == "~") ? param_name : std::string("~") + param_name;
       break;
-    case ROSParamService::COMPONENT:
+    case ROSParamService::COMPONENT_PRIVATE:
       resolved_name = std::string("~") + ros::names::append(this->getOwner()->getName(),param_name);
+      break;
+    case ROSParamService::COMPONENT_RELATIVE:
+      resolved_name = ros::names::append(this->getOwner()->getName(),param_name);
       break;
   };
 
@@ -196,7 +207,7 @@ XmlRpc::XmlRpcValue rttPropertyToXmlParam(const std::vector<T> &vec);
 XmlRpc::XmlRpcValue rttPropertyBaseToXmlParam(RTT::base::PropertyBase *prop);
 
 template<class T>
-bool castable(const RTT::base::PropertyBase *prop) 
+bool castable(const RTT::base::PropertyBase *prop)
 {
   return dynamic_cast<const Property<T>*>(prop);
 }
@@ -337,7 +348,7 @@ XmlRpc::XmlRpcValue rttPropertyBaseToXmlParam(RTT::base::PropertyBase *prop)
 
 
 bool ROSParamService::set(
-    const std::string &param_name, 
+    const std::string &param_name,
     const unsigned int policy)
 {
   RTT::Logger::In in("ROSParamService::set");
@@ -363,7 +374,7 @@ bool ROSParamService::setParam(
     return true;
   }
 
-  // Try to find a sub-service named rtt_name 
+  // Try to find a sub-service named rtt_name
   RTT::Service::shared_ptr service = this->getOwner()->provides()->getService(rtt_name);
   if (service) {
     // Set all parameters of the sub-service
@@ -380,7 +391,7 @@ bool ROSParamService::setParams(const ROSParamService::ResolutionPolicy policy)
 }
 
 bool ROSParamService::setParams(
-    RTT::Service::shared_ptr service, 
+    RTT::Service::shared_ptr service,
     const std::string& ns) {
   XmlRpc::XmlRpcValue xml_value;
   xml_value = rttPropertyToXmlParam(*(service->properties()));
@@ -412,7 +423,7 @@ bool xmlParamToProp(const XmlRpc::XmlRpcValue &xml_value, RTT::Property<Eigen::V
 template <>
 bool xmlParamToProp(const XmlRpc::XmlRpcValue &xml_value, RTT::Property<Eigen::VectorXf>* prop);
 //! Convert an XmlRpc structure value into an RTT PropertyBag property
-template <> 
+template <>
 bool xmlParamToProp<RTT::PropertyBag>(const XmlRpc::XmlRpcValue &xml_value, RTT::Property<RTT::PropertyBag>* prop);
 //! Convert an XmlRpc structure value into an abstract RTT PropertyBase
 bool xmlParamToProp( const XmlRpc::XmlRpcValue &xml_value, RTT::base::PropertyBase* prop_base);
@@ -473,7 +484,7 @@ bool xmlParamToProp(
     return false;
   }
 
-  // Make sure it's an array 
+  // Make sure it's an array
   if(xml_value.getType() != XmlRpc::XmlRpcValue::TypeArray) {
     return false;
   }
@@ -611,17 +622,17 @@ bool xmlParamToProp(
 {
   bool array_ret = false;
 
-  // Switch based on the type of XmlRpcValue 
+  // Switch based on the type of XmlRpcValue
   switch(xml_value.getType()) {
     case XmlRpc::XmlRpcValue::TypeString:
-      return 
-        xmlParamToProp(xml_value, dynamic_cast<RTT::Property<std::string>*>(prop_base)); 
+      return
+        xmlParamToProp(xml_value, dynamic_cast<RTT::Property<std::string>*>(prop_base));
     case XmlRpc::XmlRpcValue::TypeDouble:
-      return 
+      return
         xmlParamToProp(xml_value, dynamic_cast<RTT::Property<double>*>(prop_base)) ||
         xmlParamToProp(xml_value, dynamic_cast<RTT::Property<float>*>(prop_base));
     case XmlRpc::XmlRpcValue::TypeInt:
-      return 
+      return
         xmlParamToProp(xml_value, dynamic_cast<RTT::Property<double>*>(prop_base)) ||
         xmlParamToProp(xml_value, dynamic_cast<RTT::Property<float>*>(prop_base)) ||
         xmlParamToProp(xml_value, dynamic_cast<RTT::Property<int>*>(prop_base)) ||
@@ -629,8 +640,8 @@ bool xmlParamToProp(
         xmlParamToProp(xml_value, dynamic_cast<RTT::Property<char>*>(prop_base)) ||
         xmlParamToProp(xml_value, dynamic_cast<RTT::Property<unsigned char>*>(prop_base));
     case XmlRpc::XmlRpcValue::TypeBoolean:
-      return 
-        xmlParamToProp(xml_value, dynamic_cast<RTT::Property<bool>*>(prop_base)); 
+      return
+        xmlParamToProp(xml_value, dynamic_cast<RTT::Property<bool>*>(prop_base));
     case XmlRpc::XmlRpcValue::TypeArray:
       array_ret =
         xmlParamToProp(xml_value, dynamic_cast<RTT::Property<std::vector<std::string> >*>(prop_base)) ||
@@ -669,7 +680,7 @@ bool xmlParamToProp(
 }
 
 bool ROSParamService::get(
-    const std::string &param_name, 
+    const std::string &param_name,
     const unsigned int policy)
 {
   RTT::Logger::In in("ROSParamService::get");
@@ -730,7 +741,7 @@ bool ROSParamService::getParams(const ROSParamService::ResolutionPolicy policy)
 }
 
 bool ROSParamService::getParams(
-    RTT::Service::shared_ptr service, 
+    RTT::Service::shared_ptr service,
     const std::string& ns)
 {
   RTT::Logger::In in("ROSParamService::getParams");


### PR DESCRIPTION
This PR adds some operations for ops scripts for the standard types : 
- bool --> getBool, setBool
- int --> getInt, setInt
- double --> getDouble, setDouble
- float 
  [rosparam_test.ops.zip](https://github.com/orocos/rtt_ros_integration/files/445319/rosparam_test.ops.zip)

--> getFloat, setFloat
- string --> getString, setString

and the according std::vector<T> : getVectorOfDouble ...

``` ruby
#!/usr/bin/env deployer
require("print")
import("rtt_rosnode")
import("rtt_rosparam")
loadService("this","rosparam")

# Experience parameters
var string robot_name
var double some_double
var bool use_sim_time
var array gains

# get them form rosparam
rosparam.getString("robot_name",robot_name)
rosparam.getDouble("~super_double",some_double)
rosparam.getBool("/use_sim_time",use_sim_time)
rosparam.getVectorOfDouble("super_gains",gains)

```

Test:

``` ruby
#!/usr/bin/env deployer
require("print")
import("rtt_rosnode")
import("rtt_rosparam")
loadService("this","rosparam")

var array s = array(1.0,2.0,3.0,4.4)
var array r

rosparam.setVectorOfDouble("/test_vec",s)
rosparam.getVectorOfDouble("/test_vec",r)

if(r[0] == 1.0 && r[1] == 2.0 && r[2] == 3.0 && r[3] == 4.4) then
    print.ln("Vector Success ")
else
    print.ln("Vector Failed ")

var string name = "orocos"
var string name_rec

rosparam.setString("/test_string",name)
rosparam.getString("/test_string",name_rec)

if(name_rec == "orocos") then
    print.ln("String Success --> "+name_rec)
else
    print.ln("String Failed ")
```
