### PR TITLE
rtt_roscomm: added operations disconnect() and disconnectAll() to the rosservice service

### DIFF
--- a/rtt_roscomm/README.md
+++ b/rtt_roscomm/README.md
@@ -62,6 +62,14 @@ The task-scoped RTT service `rosservice` provides the following operations:
     (like `/some/ros/ns/my_service`)
   * `ROS_SERVICE_TYPE`: The full typename of the service (like
     `std_srvs/Empty`)
+* `rosservice.disconnect(ROS_SERVICE_NAME)`
+  * Disconnects an RTT operation or operation caller from an associated ROS
+    service server or client..
+  * `ROS_SERVICE_NAME`: The name of the service client/server in the ROS graph
+    (like `/some/ros/ns/my_service`)
+* `rosservice.disconnectAll()`
+  * Disconnects all RTT operations and operation callers from associated ROS
+    service servers or clients.
 
 The global RTT service `rosservice_registry` provides the following operations:
 * `rosservice_registry.registerServiceFactory(FACTORY)`: Register a ROS service

--- a/rtt_roscomm/include/rtt_roscomm/rosservice.h
+++ b/rtt_roscomm/include/rtt_roscomm/rosservice.h
@@ -11,12 +11,18 @@ namespace rtt_rosservice {
   public:
     ROSService(RTT::TaskContext *owner) :
       RTT::ServiceRequester("rosservice",owner),
-      connect("connect")
+      connect("connect"),
+      disconnect("disconnect"),
+      disconnectAll("disconnectAll")
     {
       this->addOperationCaller(connect);
+      this->addOperationCaller(disconnect);
+      this->addOperationCaller(disconnectAll);
     }
 
     RTT::OperationCaller<bool(const std::string &, const std::string &, const std::string &)> connect;
+    RTT::OperationCaller<bool(const std::string &)> disconnect;
+    RTT::OperationCaller<void()> disconnectAll;
   };
 }
 


### PR DESCRIPTION
This PR adds two new operations to the `rosservice` Orocos service provided by package `rtt_roscomm`:

* `bool disconnect(service_name)`: Disconnects an RTT operation or operation caller from an associated ROS service server or client
* `void disconnectAll()`: Disconnects all RTT operations and operation callers from associated ROS service servers or clients