### PR TITLE
rtt_dynamic_reconfigure: report updated property values in the service response

### DIFF
--- a/rtt_dynamic_reconfigure/include/orocos/rtt_dynamic_reconfigure/server.h
+++ b/rtt_dynamic_reconfigure/include/orocos/rtt_dynamic_reconfigure/server.h
@@ -63,7 +63,7 @@
 namespace rtt_dynamic_reconfigure {
 
 template <class ConfigType> class Server;
-typedef bool (UpdateCallbackSignature)(const RTT::PropertyBag &source, uint32_t level);
+typedef bool (UpdateCallbackSignature)(RTT::PropertyBag &bag, uint32_t level);
 typedef void (NotifyCallbackSignature)(uint32_t level);
 
 /**
@@ -607,7 +607,7 @@ private:
         if (!updater()->propertiesFromConfig(new_config, level, bag)) return false;
         if (!update_callback_.ready() || !update_callback_(bag, level)) return false;
         if (notify_callback_.ready()) notify_callback_(level);
-        updater()->configFromProperties(new_config, *(getOwner()->properties()));
+        updater()->configFromProperties(new_config, bag);
 
         updateConfigInternal(new_config);
         new_config.__toMessage__(rsp.config);
@@ -627,9 +627,9 @@ private:
             update_pub_.publish(msg);
     }
 
-    bool updatePropertiesDefaultImpl(const RTT::PropertyBag &source, uint32_t)
+    bool updatePropertiesDefaultImpl(RTT::PropertyBag &bag, uint32_t)
     {
-        return RTT::updateProperties(*(getOwner()->properties()), source);
+        return RTT::updateProperties(*(getOwner()->properties()), bag);
     }
 };
 

--- a/rtt_dynamic_reconfigure/include/orocos/rtt_dynamic_reconfigure/server.h
+++ b/rtt_dynamic_reconfigure/include/orocos/rtt_dynamic_reconfigure/server.h
@@ -607,6 +607,7 @@ private:
         if (!updater()->propertiesFromConfig(new_config, level, bag)) return false;
         if (!update_callback_.ready() || !update_callback_(bag, level)) return false;
         if (notify_callback_.ready()) notify_callback_(level);
+        updater()->configFromProperties(new_config, *(getOwner()->properties()));
 
         updateConfigInternal(new_config);
         new_config.__toMessage__(rsp.config);


### PR DESCRIPTION
The user can provide a `updateProperties(bag, level)` operation that replaces the default implementation. Until now it was not possible to change values in the source bag and report the updated values back to the client in the service response. This missing functionality is implemented by this PR.

Unfortunately it is not backwards-compatible as the signature of the callback operation changes to `bool (RTT::PropertyBag &bag, uint32_t level)`.

So I propose to merge the patch to toolchain-2.9 only.