### PR TITLE
rtt_roscomm: fix caller engine in RosServiceServerProxyBase

### DIFF
--- a/rtt_roscomm/include/rtt_roscomm/rtt_rosservice_proxy.h
+++ b/rtt_roscomm/include/rtt_roscomm/rtt_rosservice_proxy.h
@@ -4,6 +4,7 @@
 #include <ros/ros.h>
 
 #include <rtt/RTT.hpp>
+#include <rtt/internal/GlobalEngine.hpp>
 #include <rtt/plugin/ServicePlugin.hpp>
 
 //! Abstract ROS Service Proxy
@@ -34,7 +35,7 @@ public:
     // Link the caller with the operation
     return proxy_operation_caller_->setImplementation(
         operation->getLocalOperation(),
-        owner->engine());
+        RTT::internal::GlobalEngine::Instance());
   }
 
 protected:


### PR DESCRIPTION
This patch fixes a thread-safety issue if Orocos operations are called from ROS via the `rosservice` plugin build along with typekit packages. The caller engine was set to the owner's engine, which is typically the same as the engine that executes the operation for a typical component. If the caller and owner engine are the same, Orocos RTT until version 2.8 executes the operation directly in the thread of the caller (`isSend()` returns false in [OperationCallerInterface.hpp:79](https://github.com/orocos-toolchain/rtt/blob/toolchain-2.8/rtt/base/OperationCallerInterface.hpp#L79)). This behavior is unexpected and has a high potential for data races or segmentation faults.

The solution is to specify the `GlobalEngine` as the caller. In fact the operation will be called from the ROS spinner thread executing the ROS service callback:
- If the operation is declared as `ClientThread`, it will always be executed by the ROS spinner and it is the responsibility of the implementor to protect shared resources from concurrent access, like for any `ClientThread` operation.
- If the operation is declared as `OwnThread` and has been added to a component with `addOperation()`, it will be executed by the component's thread.
- If the operation is declared as `OwnThread` but has not been added to a component or an owner engine has been set by other means (a "free" operation), it will be executed in a ROS spinner thread directly because the implicit executor is the `GlobalEngine`. Not sure if this case is even possible with the `rosservice` plugin.