### PR TITLE
Added a ROS transport plugin for primitive types (indigo-devel)

### DIFF
--- a/rtt_ros/src/orocos/types/ros_primitives_typekit_plugin.cpp
+++ b/rtt_ros/src/orocos/types/ros_primitives_typekit_plugin.cpp
@@ -86,7 +86,7 @@ namespace ros_integration {
     void loadStringTypes();
 
     std::string ROSPrimitivesTypekitPlugin::getName(){
-	    return std::string("ros-")+"primitives";
+        return "ros-primitives";
     }
  
     bool ROSPrimitivesTypekitPlugin::loadTypes() {

--- a/rtt_roscomm/include/rtt_roscomm/rtt_rostopic_ros_msg_transporter.hpp
+++ b/rtt_roscomm/include/rtt_roscomm/rtt_rostopic_ros_msg_transporter.hpp
@@ -67,12 +67,11 @@
 
 namespace rtt_roscomm {
 
-  using namespace RTT;
   /**
    * A ChannelElement implementation to publish data over a ros topic
    */
   template<typename T>
-  class RosPubChannelElement: public base::ChannelElement<T>,public RosPublisher
+  class RosPubChannelElement: public RTT::base::ChannelElement<T>, public RosPublisher
   {
     char hostname[1024];
     std::string topicname;
@@ -82,7 +81,7 @@ namespace rtt_roscomm {
       //! We must cache the RosPublishActivity object.
     RosPublishActivity::shared_ptr act;
 
-    typename base::ChannelElement<T>::value_t sample;
+    typename RTT::base::ChannelElement<T>::value_t sample;
 
   public:
 
@@ -96,7 +95,7 @@ namespace rtt_roscomm {
      * 
      * @return ChannelElement that will publish data to topics
      */
-    RosPubChannelElement(base::PortInterface* port,const ConnPolicy& policy):
+    RosPubChannelElement(RTT::base::PortInterface* port, const RTT::ConnPolicy& policy) :
       ros_node(),
       ros_node_private("~")
     {
@@ -113,12 +112,12 @@ namespace rtt_roscomm {
         policy.name_id = namestr.str();
       }
       topicname=policy.name_id;
-      Logger::In in(topicname);
+      RTT::Logger::In in(topicname);
 
       if (port->getInterface() && port->getInterface()->getOwner()) {
-        log(Debug)<<"Creating ROS publisher for port "<<port->getInterface()->getOwner()->getName()<<"."<<port->getName()<<" on topic "<<policy.name_id<<endlog();
+        RTT::log(RTT::Debug)<<"Creating ROS publisher for port "<<port->getInterface()->getOwner()->getName()<<"."<<port->getName()<<" on topic "<<policy.name_id<<RTT::endlog();
       } else {
-        log(Debug)<<"Creating ROS publisher for port "<<port->getName()<<" on topic "<<policy.name_id<<endlog();
+        RTT::log(RTT::Debug)<<"Creating ROS publisher for port "<<port->getName()<<" on topic "<<policy.name_id<<RTT::endlog();
       }
 
       // Handle private names
@@ -132,8 +131,8 @@ namespace rtt_roscomm {
     }
 
     ~RosPubChannelElement() {
-      Logger::In in(topicname);
-      log(Debug)<<"Destroying RosPubChannelElement"<<endlog();
+      RTT::Logger::In in(topicname);
+//      RTT::log(RTT::Debug) << "Destroying RosPubChannelElement" << RTT::endlog();
       act->removePublisher( this );
     }
 
@@ -154,13 +153,13 @@ namespace rtt_roscomm {
      * @return always true/WriteSuccess
      */
 #if RTT_VERSION_GTE(2,8,99)
-    virtual WriteStatus data_sample(typename base::ChannelElement<T>::param_t sample)
+    virtual RTT::WriteStatus data_sample(typename RTT::base::ChannelElement<T>::param_t sample)
     {
       this->sample = sample;
-      return WriteSuccess;
+      return RTT::WriteSuccess;
     }
 #else
-    virtual bool data_sample(typename base::ChannelElement<T>::param_t sample)
+    virtual bool data_sample(typename RTT::base::ChannelElement<T>::param_t sample)
     {
       this->sample = sample;
       return true;
@@ -173,27 +172,27 @@ namespace rtt_roscomm {
      * @return true if publishing succeeded
      */
     bool signal(){
-      //Logger::In in(topicname);
-      //log(Debug)<<"Requesting publish"<<endlog();
+      //RTT::Logger::In in(topicname);
+      //RTT::log(RTT::Debug) << "Requesting publish" << RTT::endlog();
       return act->trigger();
     }
     
     void publish(){
       // this read should always succeed since signal() means 'data available in a data element'.
-      typename base::ChannelElement<T>::shared_ptr input = this->getInput();
-      while( input && (input->read(sample,false) == NewData) )
+      typename RTT::base::ChannelElement<T>::shared_ptr input = this->getInput();
+      while( input && (input->read(sample,false) == RTT::NewData) )
         write(sample);
     }
 
 #if RTT_VERSION_GTE(2,8,99)
-    WriteStatus write(typename base::ChannelElement<T>::param_t sample)
+    RTT::WriteStatus write(typename RTT::base::ChannelElement<T>::param_t sample)
 #else
-    bool write(typename base::ChannelElement<T>::param_t sample)
+    bool write(typename RTT::base::ChannelElement<T>::param_t sample)
 #endif
     {
       ros_pub.publish(sample);
 #if RTT_VERSION_GTE(2,8,99)
-      return WriteSuccess;
+      return RTT::WriteSuccess;
 #else
       return true;
 #endif
@@ -205,7 +204,7 @@ namespace rtt_roscomm {
    * A ChannelElement implementation to subscribe to data over a ros topic
    */
   template<typename T>
-  class RosSubChannelElement: public base::ChannelElement<T>
+  class RosSubChannelElement: public RTT::base::ChannelElement<T>
   {
     std::string topicname;
     ros::NodeHandle ros_node;
@@ -222,16 +221,16 @@ namespace rtt_roscomm {
      * 
      * @return ChannelElement that will publish data to topics
      */
-    RosSubChannelElement(base::PortInterface* port, const ConnPolicy& policy) :
+    RosSubChannelElement(RTT::base::PortInterface* port, const RTT::ConnPolicy& policy) :
       ros_node(),
       ros_node_private("~")
     {
       topicname=policy.name_id;
-      Logger::In in(topicname);
+      RTT::Logger::In in(topicname);
       if (port->getInterface() && port->getInterface()->getOwner()) {
-        log(Debug)<<"Creating ROS subscriber for port "<<port->getInterface()->getOwner()->getName()<<"."<<port->getName()<<" on topic "<<policy.name_id<<endlog();
+        RTT::log(RTT::Debug)<<"Creating ROS subscriber for port "<<port->getInterface()->getOwner()->getName()<<"."<<port->getName()<<" on topic "<<policy.name_id<<RTT::endlog();
       } else {
-        log(Debug)<<"Creating ROS subscriber for port "<<port->getName()<<" on topic "<<policy.name_id<<endlog();
+        RTT::log(RTT::Debug)<<"Creating ROS subscriber for port "<<port->getName()<<" on topic "<<policy.name_id<<RTT::endlog();
       }
       if(topicname.length() > 1 && topicname.at(0) == '~') {
         ros_sub = ros_node_private.subscribe(policy.name_id.substr(1), policy.size > 0 ? policy.size : 1, &RosSubChannelElement::newData, this); // minimum queue_size 1
@@ -241,8 +240,8 @@ namespace rtt_roscomm {
     }
 
     ~RosSubChannelElement() {
-      Logger::In in(topicname);
-      log(Debug)<<"Destroying RosSubChannelElement"<<endlog();
+      RTT::Logger::In in(topicname);
+//      RTT::log(RTT::Debug)<<"Destroying RosSubChannelElement"<<RTT::endlog();
     }
 
     virtual bool inputReady() {
@@ -255,7 +254,7 @@ namespace rtt_roscomm {
      * @param msg The received message
      */
     void newData(const T& msg){
-      typename base::ChannelElement<T>::shared_ptr output = this->getOutput();
+      typename RTT::base::ChannelElement<T>::shared_ptr output = this->getOutput();
       if (output)
           output->write(msg);
     }
@@ -264,31 +263,31 @@ namespace rtt_roscomm {
   template <class T>
   class RosMsgTransporter : public RTT::types::TypeTransporter
   {
-    virtual base::ChannelElementBase::shared_ptr createStream (base::PortInterface *port, const ConnPolicy &policy, bool is_sender) const{
-      base::ChannelElementBase::shared_ptr channel;
+    virtual RTT::base::ChannelElementBase::shared_ptr createStream (RTT::base::PortInterface *port, const RTT::ConnPolicy &policy, bool is_sender) const{
+      RTT::base::ChannelElementBase::shared_ptr channel;
 
       // Pull semantics are not supported by the ROS message transport.
       if (policy.pull) {
-          RTT::log(RTT::Error) << "Pull connections are not supported by the ROS message transport." << endlog();
-          return base::ChannelElementBase::shared_ptr();
+          RTT::log(RTT::Error) << "Pull connections are not supported by the ROS message transport." << RTT::endlog();
+          return RTT::base::ChannelElementBase::shared_ptr();
       }
 
       // Check if this node is initialized
       if (!ros::ok()) {
-          RTT::log(RTT::Error) << "Cannot create ROS message transport because the node is not initialized or already shutting down. Did you import package rtt_rosnode before?" << endlog();
-          return base::ChannelElementBase::shared_ptr();
+          RTT::log(RTT::Error) << "Cannot create ROS message transport because the node is not initialized or already shutting down. Did you import package rtt_rosnode before?" << RTT::endlog();
+          return RTT::base::ChannelElementBase::shared_ptr();
       }
 
       if (is_sender){
         channel = new RosPubChannelElement<T>(port, policy);
 
         if (policy.type == RTT::ConnPolicy::UNBUFFERED){
-          log(Debug) << "Creating unbuffered publisher connection for port " << port->getName() << ". This may not be real-time safe!" << endlog();
+          RTT::log(RTT::Debug) << "Creating unbuffered publisher connection for port " << port->getName() << ". This may not be real-time safe!" << RTT::endlog();
           return channel;
         }
 
-        base::ChannelElementBase::shared_ptr buf = internal::ConnFactory::buildDataStorage<T>(policy);
-        if (!buf) return base::ChannelElementBase::shared_ptr();
+        RTT::base::ChannelElementBase::shared_ptr buf = RTT::internal::ConnFactory::buildDataStorage<T>(policy);
+        if (!buf) return RTT::base::ChannelElementBase::shared_ptr();
 #if RTT_VERSION_GTE(2,8,99)
         buf->connectTo(channel);
 #else
@@ -300,8 +299,8 @@ namespace rtt_roscomm {
         channel = new RosSubChannelElement<T>(port, policy);
 
 #if !RTT_VERSION_GTE(2,8,99)
-        base::ChannelElementBase::shared_ptr buf = internal::ConnFactory::buildDataStorage<T>(policy);
-        if (!buf) return base::ChannelElementBase::shared_ptr();
+        RTT::base::ChannelElementBase::shared_ptr buf = RTT::internal::ConnFactory::buildDataStorage<T>(policy);
+        if (!buf) return RTT::base::ChannelElementBase::shared_ptr();
         channel->setOutput(buf);
 #endif
       }

--- a/tests/rtt_roscomm_tests/package.xml
+++ b/tests/rtt_roscomm_tests/package.xml
@@ -16,6 +16,8 @@
   <build_depend>ocl</build_depend>
 
   <test_depend>rtt_rosnode</test_depend>
+  <!-- <test_depend>rtt_std_msgs</test_depend> -->
+  <test_depend>rtt_std_srvs</test_depend>
   <test_depend>rosbash</test_depend> <!-- required for rosrun command -->
   <test_depend>rostest</test_depend>
 

--- a/tests/rtt_roscomm_tests/test/transport_tests.cpp
+++ b/tests/rtt_roscomm_tests/test/transport_tests.cpp
@@ -10,10 +10,17 @@
 #include <rtt_roscomm/rtt_rostopic.h>
 #include <std_msgs/typekit/String.h>
 
+#include <ros/names.h>
+#include <ros/this_node.h>
+
 #include <gtest/gtest.h>
+
+#include <algorithm>
 
 TEST(TransportTest, OutOfBandTest)
 {
+  ros::V_string advertised_topics, subscribed_topics;
+
   // Import plugins
   EXPECT_TRUE(RTT::ComponentLoader::Instance()->import("rtt_std_msgs", "" ));
   EXPECT_TRUE(RTT::ComponentLoader::Instance()->import("rtt_rosnode", "" ));
@@ -22,17 +29,43 @@ TEST(TransportTest, OutOfBandTest)
   RTT::InputPort<std_msgs::String> in("in");
 
   // Create an out-of-band connection with ROS transport (a publisher/subscriber pair)
-  EXPECT_TRUE(out.connectTo(&in, rtt_roscomm::topicLatched("~talker")));
+  std::string topic = ros::names::resolve("~talker");
+  EXPECT_TRUE(out.connectTo(&in, rtt_roscomm::topicLatched(topic)));
 
+  // Check that the publisher and subscriber have been successfully registered:
+  ros::this_node::getAdvertisedTopics(advertised_topics);
+  EXPECT_TRUE(std::find(advertised_topics.begin(), advertised_topics.end(),
+                        topic) != advertised_topics.end());
+  ros::this_node::getSubscribedTopics(subscribed_topics);
+  EXPECT_TRUE(std::find(subscribed_topics.begin(), subscribed_topics.end(),
+                        topic) != subscribed_topics.end());
+
+  // publish and latch one sample
   std_msgs::String sample;
   sample.data = "Hello world!";
   out.write(sample);
 
   usleep(1000000);
 
+  // read sample through input port
   sample.data.clear();
   EXPECT_EQ(RTT::NewData, in.read(sample) );
   EXPECT_EQ("Hello world!", sample.data);
+
+  // Close connection
+  out.disconnect();
+  EXPECT_FALSE(out.connected());
+  EXPECT_FALSE(in.connected());
+
+  // Check that the publisher and subscriber have been destroyed:
+  advertised_topics.clear();
+  subscribed_topics.clear();
+  ros::this_node::getAdvertisedTopics(advertised_topics);
+  EXPECT_FALSE(std::find(advertised_topics.begin(), advertised_topics.end(),
+                        topic) != advertised_topics.end());
+  ros::this_node::getSubscribedTopics(subscribed_topics);
+  EXPECT_FALSE(std::find(subscribed_topics.begin(), subscribed_topics.end(),
+                        topic) != subscribed_topics.end());
 }
 
 int main(int argc, char** argv) {

--- a/tests/rtt_roscomm_tests/test/transport_tests.cpp
+++ b/tests/rtt_roscomm_tests/test/transport_tests.cpp
@@ -8,10 +8,15 @@
 #include <rtt/deployment/ComponentLoader.hpp>
 
 #include <rtt_roscomm/rtt_rostopic.h>
+#include <rtt_roscomm/rosservice.h>
 #include <std_msgs/typekit/String.h>
+#include <std_srvs/Empty.h>
 
 #include <ros/names.h>
+#include <ros/service_manager.h>
 #include <ros/this_node.h>
+
+#include <boost/weak_ptr.hpp>
 
 #include <gtest/gtest.h>
 
@@ -22,8 +27,9 @@ TEST(TransportTest, OutOfBandTest)
   ros::V_string advertised_topics, subscribed_topics;
 
   // Import plugins
-  EXPECT_TRUE(RTT::ComponentLoader::Instance()->import("rtt_std_msgs", "" ));
-  EXPECT_TRUE(RTT::ComponentLoader::Instance()->import("rtt_rosnode", "" ));
+  ASSERT_TRUE(RTT::ComponentLoader::Instance()->import("rtt_rosnode", "" ));
+  ASSERT_TRUE(RTT::ComponentLoader::Instance()->import("rtt_roscomm", "" ));
+  ASSERT_TRUE(RTT::ComponentLoader::Instance()->import("rtt_std_msgs", "" ));
 
   RTT::OutputPort<std_msgs::String> out("out");
   RTT::InputPort<std_msgs::String> in("in");
@@ -66,6 +72,50 @@ TEST(TransportTest, OutOfBandTest)
   ros::this_node::getSubscribedTopics(subscribed_topics);
   EXPECT_FALSE(std::find(subscribed_topics.begin(), subscribed_topics.end(),
                         topic) != subscribed_topics.end());
+}
+
+static int callback_called = 0;
+bool callback(std_srvs::Empty::Request&, std_srvs::Empty::Response&)
+{
+  ++callback_called;
+  return true;
+}
+
+TEST(TransportTest, ServiceServerTest)
+{
+  std::string service = ros::names::resolve("~empty");
+
+  // Import plugins
+  ASSERT_TRUE(RTT::ComponentLoader::Instance()->import("rtt_rosnode", "" ));
+  ASSERT_TRUE(RTT::ComponentLoader::Instance()->import("rtt_roscomm", "" ));
+  ASSERT_TRUE(RTT::ComponentLoader::Instance()->import("rtt_std_srvs", "" ));
+
+  // Create a TaskContext
+  RTT::TaskContext *tc = new RTT::TaskContext("TaskContext");
+  tc->addOperation("empty", &callback);
+
+  // Load the rosservice service
+  boost::weak_ptr<rtt_rosservice::ROSService> rosservice;
+  rosservice = tc->getProvider<rtt_rosservice::ROSService>("rosservice");
+  ASSERT_FALSE(rosservice.expired());
+
+  // Create a service server
+  EXPECT_TRUE(rosservice.lock()->connect("empty", service, "std_srvs/Empty"));
+
+  // Check that the service server has been successfully registered:
+  EXPECT_TRUE(ros::ServiceManager::instance()->lookupServicePublication(service));
+
+  // Create a service client
+  RTT::OperationCaller<bool(std_srvs::Empty::Request&, std_srvs::Empty::Response&)> service_caller("empty");
+  tc->requires()->addOperationCaller(service_caller);
+  EXPECT_TRUE(rosservice.lock()->connect("empty", service, "std_srvs/Empty"));
+  EXPECT_TRUE(service_caller.ready());
+
+  // Call the service
+  EXPECT_EQ(0, callback_called);
+  std_srvs::Empty empty;
+  EXPECT_TRUE(service_caller(empty.request, empty.response));
+  EXPECT_EQ(1, callback_called);
 }
 
 int main(int argc, char** argv) {

--- a/tests/rtt_roscomm_tests/test/transport_tests.cpp
+++ b/tests/rtt_roscomm_tests/test/transport_tests.cpp
@@ -27,16 +27,21 @@ TEST(TransportTest, OutOfBandTest)
   ros::V_string advertised_topics, subscribed_topics;
 
   // Import plugins
+  ASSERT_TRUE(RTT::ComponentLoader::Instance()->import("rtt_ros", "" ));
   ASSERT_TRUE(RTT::ComponentLoader::Instance()->import("rtt_rosnode", "" ));
   ASSERT_TRUE(RTT::ComponentLoader::Instance()->import("rtt_roscomm", "" ));
   ASSERT_TRUE(RTT::ComponentLoader::Instance()->import("rtt_std_msgs", "" ));
 
   RTT::OutputPort<std_msgs::String> out("out");
-  RTT::InputPort<std_msgs::String> in("in");
+  RTT::InputPort<std::string> in("in");
 
   // Create an out-of-band connection with ROS transport (a publisher/subscriber pair)
+  // NOTE: The rtt-ros-primitives-transport installs a transport for the std::string type
+  // which is compatible to std_msgs/String.
   std::string topic = ros::names::resolve("~talker");
-  EXPECT_TRUE(out.connectTo(&in, rtt_roscomm::topicLatched(topic)));
+//  EXPECT_TRUE(out.connectTo(&in, rtt_roscomm::topicLatched(topic)));
+  EXPECT_TRUE(out.createStream(rtt_roscomm::topicLatched(topic)));
+  EXPECT_TRUE(in.createStream(rtt_roscomm::topic(topic)));
 
   // Check that the publisher and subscriber have been successfully registered:
   ros::this_node::getAdvertisedTopics(advertised_topics);
@@ -50,17 +55,17 @@ TEST(TransportTest, OutOfBandTest)
   std_msgs::String sample;
   sample.data = "Hello world!";
   out.write(sample);
-
   usleep(1000000);
 
   // read sample through input port
-  sample.data.clear();
-  EXPECT_EQ(RTT::NewData, in.read(sample) );
-  EXPECT_EQ("Hello world!", sample.data);
+  std::string received;
+  EXPECT_EQ(RTT::NewData, in.read(received) );
+  EXPECT_EQ(sample.data, received);
 
   // Close connection
   out.disconnect();
   EXPECT_FALSE(out.connected());
+  in.disconnect();
   EXPECT_FALSE(in.connected());
 
   // Check that the publisher and subscriber have been destroyed:
@@ -103,7 +108,7 @@ TEST(TransportTest, ServiceServerTest)
   EXPECT_TRUE(rosservice.lock()->connect("empty", service, "std_srvs/Empty"));
 
   // Check that the service server has been successfully registered:
-  EXPECT_TRUE(ros::ServiceManager::instance()->lookupServicePublication(service));
+  EXPECT_TRUE(ros::ServiceManager::instance()->lookupServicePublication(service).get());
 
   // Create a service client
   RTT::OperationCaller<bool(std_srvs::Empty::Request&, std_srvs::Empty::Response&)> service_caller("empty");

--- a/typekits/rtt_std_msgs/CMakeLists.txt
+++ b/typekits/rtt_std_msgs/CMakeLists.txt
@@ -3,12 +3,19 @@ project(rtt_std_msgs)
 
 find_package(catkin REQUIRED COMPONENTS rtt_roscomm)
 
+include_directories(include/orocos)
+
 ros_generate_rtt_typekit(std_msgs)
 
 if(NOT DEFINED CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "Release")
   set(CMAKE_BUILD_TYPE MinSizeRel)
 endif()
 orocos_plugin(rtt-ros-primitives-transport src/ros_primitives_transport_plugin.cpp)
+
+install(
+  DIRECTORY include/orocos/std_msgs
+  DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}/orocos
+)
 
 orocos_generate_package(
   DEPENDS std_msgs

--- a/typekits/rtt_std_msgs/CMakeLists.txt
+++ b/typekits/rtt_std_msgs/CMakeLists.txt
@@ -5,6 +5,11 @@ find_package(catkin REQUIRED COMPONENTS rtt_roscomm)
 
 ros_generate_rtt_typekit(std_msgs)
 
+if(NOT DEFINED CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "Release")
+  set(CMAKE_BUILD_TYPE MinSizeRel)
+endif()
+orocos_plugin(rtt-ros-primitives-transport src/ros_primitives_transport_plugin.cpp)
+
 orocos_generate_package(
   DEPENDS std_msgs
   DEPENDS_TARGETS rtt_roscomm

--- a/typekits/rtt_std_msgs/include/orocos/std_msgs/vector_multi_array_adapter.h
+++ b/typekits/rtt_std_msgs/include/orocos/std_msgs/vector_multi_array_adapter.h
@@ -1,0 +1,180 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, Intermodalics BVBA
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of of the copyright holders nor the names of
+ *     any contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#ifndef STD_MSGS_VECTOR_MULTI_ARRAY_ADAPTER_H
+#define STD_MSGS_VECTOR_MULTI_ARRAY_ADAPTER_H
+
+#include <std_msgs/Float32MultiArray.h>
+#include <std_msgs/Float64MultiArray.h>
+#include <std_msgs/Int16MultiArray.h>
+#include <std_msgs/Int32MultiArray.h>
+#include <std_msgs/Int64MultiArray.h>
+#include <std_msgs/Int8MultiArray.h>
+#include <std_msgs/UInt16MultiArray.h>
+#include <std_msgs/UInt32MultiArray.h>
+#include <std_msgs/UInt64MultiArray.h>
+#include <std_msgs/UInt8MultiArray.h>
+
+#include <ros/message_traits.h>
+#include <ros/serialization.h>
+
+namespace std_msgs {
+
+// container for a std::vector<T, ContainerAllocator> with pointer semantics
+template <typename T, class ContainerAllocator = std::allocator<T> >
+class VectorMultiArrayAdapter
+{
+public:
+  typedef std::vector<T, ContainerAllocator> VectorType;
+
+  VectorMultiArrayAdapter()
+    : vector_(&owned_vector_) {}
+  VectorMultiArrayAdapter(VectorType &v)
+    : vector_(&v) {}
+  VectorMultiArrayAdapter(const VectorType &v)
+    : vector_(const_cast<VectorType*>(&v)) {}
+
+  VectorType *operator->() { return vector_; }
+  const VectorType *operator->() const { return vector_; }
+  VectorType &operator*() { return *vector_; }
+  const VectorType &operator*() const { return *vector_; }
+
+private:
+  VectorType owned_vector_;
+  VectorType* vector_;
+};
+
+} // namespace std_msgs
+
+
+#define STD_MSGS_DEFINE_MULTIARRAY_TRAITS(value_type, msg, static_md5sum1, static_md5sum2) \
+  namespace ros \
+  { \
+  namespace message_traits \
+  { \
+    \
+    template <class ContainerAllocator> struct MD5Sum<std_msgs::VectorMultiArrayAdapter<value_type, ContainerAllocator> > \
+    { \
+      static const char* value() \
+      { \
+        return MD5Sum<std_msgs::msg>::value(); \
+      } \
+      \
+      static const char* value(const std_msgs::VectorMultiArrayAdapter<value_type, ContainerAllocator> &) \
+      { \
+        return value(); \
+      } \
+    }; \
+    \
+    template <class ContainerAllocator> struct DataType<std_msgs::VectorMultiArrayAdapter<value_type, ContainerAllocator> > \
+    { \
+      static const char* value() \
+      { \
+        return DataType<std_msgs::msg>::value(); \
+      } \
+     \
+      static const char* value(const std_msgs::VectorMultiArrayAdapter<value_type, ContainerAllocator> &) \
+      { \
+        return value(); \
+      } \
+    }; \
+    \
+    template <class ContainerAllocator> struct Definition<std_msgs::VectorMultiArrayAdapter<value_type, ContainerAllocator> > \
+    { \
+      static const char* value() \
+      { \
+        return Definition<std_msgs::msg>::value(); \
+      } \
+      \
+      static const char* value(const std_msgs::VectorMultiArrayAdapter<value_type, ContainerAllocator> &) \
+      { \
+        return value(); \
+      } \
+    }; \
+    \
+  } \
+  }
+
+STD_MSGS_DEFINE_MULTIARRAY_TRAITS(float, Float32MultiArray, 0x6a40e0ffa6a17a50ULL, 0x3ac3f8616991b1f6ULL)
+STD_MSGS_DEFINE_MULTIARRAY_TRAITS(double, Float64MultiArray, 0x4b7d974086d4060eULL, 0x7db4613a7e6c3ba4ULL)
+STD_MSGS_DEFINE_MULTIARRAY_TRAITS(int16_t, Int16MultiArray, 0xd9338d7f523fcb69ULL, 0x2fae9d0a0e9f067cULL)
+STD_MSGS_DEFINE_MULTIARRAY_TRAITS(int32_t, Int32MultiArray, 0x1d99f79f8b325b44ULL, 0xfee908053e9c945bULL)
+STD_MSGS_DEFINE_MULTIARRAY_TRAITS(int64_t, Int64MultiArray, 0x54865aa6c65be044ULL, 0x8113a2afc6a49270ULL)
+STD_MSGS_DEFINE_MULTIARRAY_TRAITS(int8_t, Int8MultiArray, 0xd7c1af35a1b4781bULL, 0xbe79e03dd94b7c13ULL)
+STD_MSGS_DEFINE_MULTIARRAY_TRAITS(uint16_t, UInt16MultiArray, 0x52f264f1c973c4b7ULL, 0x3790d384c6cb4484ULL)
+STD_MSGS_DEFINE_MULTIARRAY_TRAITS(uint32_t, UInt32MultiArray, 0x4d6a180abc9be191ULL, 0xb96a7eda6c8a233dULL)
+STD_MSGS_DEFINE_MULTIARRAY_TRAITS(uint64_t, UInt64MultiArray, 0x6088f127afb1d6c7ULL, 0x2927aa1247e945afULL)
+STD_MSGS_DEFINE_MULTIARRAY_TRAITS(uint8_t, UInt8MultiArray, 0x82373f1612381bb6ULL, 0xee473b5cd6f5d89cULL)
+
+namespace ros {
+namespace serialization {
+
+template <typename T, class ContainerAllocator>
+struct Serializer<std_msgs::VectorMultiArrayAdapter<T, ContainerAllocator> >
+{
+  typedef std_msgs::VectorMultiArrayAdapter<T, ContainerAllocator> AdaptedType;
+  typedef typename AdaptedType::VectorType VectorType;
+  typedef T value_type;
+
+  template<typename Stream>
+  inline static void write(Stream& stream, const AdaptedType& v)
+  {
+    // Note: We mimic serialization of a std_msgs/MultiArrayLayout here because
+    // we cannot use a static const instance here due to the variable field dim[0].size.
+    stream.next((uint32_t)1);         // layout.dim.size()
+    stream.next(std::string());       // layout.dim[0].label
+    stream.next((uint32_t)v->size()); // layout.dim[0].size
+    stream.next((uint32_t)1);         // layout.dim[0].stride
+    stream.next((uint32_t)0);         // layout.data_offset
+    stream.next(*v);
+  }
+
+  template<typename Stream>
+  inline static void read(Stream& stream, AdaptedType& v)
+  {
+    std_msgs::MultiArrayLayout_<ContainerAllocator> layout;
+    stream.next(layout); // layout is ignored on read!
+    stream.next(*v);
+  }
+
+  inline static uint32_t serializedLength(const AdaptedType& v)
+  {
+    return 20 + serializationLength(*v);
+  }
+};
+
+} // namespace serialization
+} // namespace ros
+
+#endif // STD_MSGS_VECTOR_MULTI_ARRAY_ADAPTER_H

--- a/typekits/rtt_std_msgs/include/orocos/std_msgs/vector_multi_array_adapter.h
+++ b/typekits/rtt_std_msgs/include/orocos/std_msgs/vector_multi_array_adapter.h
@@ -46,6 +46,7 @@
 #include <std_msgs/UInt64MultiArray.h>
 #include <std_msgs/UInt8MultiArray.h>
 
+#include <ros/assert.h>
 #include <ros/message_traits.h>
 #include <ros/serialization.h>
 
@@ -88,6 +89,8 @@ private:
     { \
       static const char* value() \
       { \
+        ROS_STATIC_ASSERT(MD5Sum<std_msgs::msg>::static_value1 == static_md5sum1); \
+        ROS_STATIC_ASSERT(MD5Sum<std_msgs::msg>::static_value2 == static_md5sum2); \
         return MD5Sum<std_msgs::msg>::value(); \
       } \
       \
@@ -144,8 +147,6 @@ template <typename T, class ContainerAllocator>
 struct Serializer<std_msgs::VectorMultiArrayAdapter<T, ContainerAllocator> >
 {
   typedef std_msgs::VectorMultiArrayAdapter<T, ContainerAllocator> AdaptedType;
-  typedef typename AdaptedType::VectorType VectorType;
-  typedef T value_type;
 
   template<typename Stream>
   inline static void write(Stream& stream, const AdaptedType& v)

--- a/typekits/rtt_std_msgs/package.xml
+++ b/typekits/rtt_std_msgs/package.xml
@@ -22,14 +22,17 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>rtt_ros</build_depend>
   <build_depend>rtt_roscomm</build_depend>
   <build_depend>std_msgs</build_depend>
 
+  <run_depend>rtt_ros</run_depend>
   <run_depend>rtt_roscomm</run_depend>
   <run_depend>std_msgs</run_depend>
 
   <export>
     <rtt_ros>
+      <plugin_depend>rtt_ros</plugin_depend>
       <plugin_depend>rtt_roscomm</plugin_depend>
     </rtt_ros>
   </export>

--- a/typekits/rtt_std_msgs/src/ros_primitives_transport_plugin.cpp
+++ b/typekits/rtt_std_msgs/src/ros_primitives_transport_plugin.cpp
@@ -1,0 +1,74 @@
+// required for ROS_STATIC_ASSERT(), not included in <std_msgs/builtin_string.h>
+#include <ros/assert.h>
+
+#include <std_msgs/builtin_bool.h>
+#include <std_msgs/builtin_double.h>
+#include <std_msgs/builtin_float.h>
+#include <std_msgs/builtin_int8.h>
+#include <std_msgs/builtin_int16.h>
+#include <std_msgs/builtin_int32.h>
+#include <std_msgs/builtin_int64.h>
+#include <std_msgs/builtin_string.h>
+#include <std_msgs/builtin_uint8.h>
+#include <std_msgs/builtin_uint16.h>
+#include <std_msgs/builtin_uint32.h>
+#include <std_msgs/builtin_uint64.h>
+
+#include <std_msgs/Duration.h>
+#include <std_msgs/Time.h>
+#include <ros/time.h>
+
+#include <rtt_roscomm/rtt_rostopic_ros_msg_transporter.hpp>
+#include <rtt_roscomm/rtt_rostopic.h>
+#include <rtt/types/TransportPlugin.hpp>
+#include <rtt/types/TypekitPlugin.hpp>
+#include <rtt/rt_string.hpp>
+
+
+// There are no message_traits for ros::Time and ros::Duration, so we define it here.
+STD_MSGS_DEFINE_BUILTIN_TRAITS(::ros::Duration, Duration, 0x3e286caf4241d664ULL, 0xe55f3ad380e2ae46ULL)
+STD_MSGS_DEFINE_BUILTIN_TRAITS(::ros::Time, Time, 0xcd7166c74c552c31ULL, 0x1fbcc2fe5a7bc289ULL)
+
+namespace rtt_std_msgs {
+  using namespace RTT;
+  using rtt_roscomm::RosMsgTransporter;
+
+  struct ROSPrimitivesPlugin
+    : public types::TransportPlugin
+  {
+    bool registerTransport(std::string name, types::TypeInfo* ti)
+    {
+      if (name == "bool") { return ti->addProtocol(ORO_ROS_PROTOCOL_ID, new RosMsgTransporter<bool>());} else
+      if (name == "duration") { return ti->addProtocol(ORO_ROS_PROTOCOL_ID, new RosMsgTransporter<ros::Duration>());} else
+      if (name == "float32") { return ti->addProtocol(ORO_ROS_PROTOCOL_ID, new RosMsgTransporter<float>());} else
+      if (name == "float64") { return ti->addProtocol(ORO_ROS_PROTOCOL_ID, new RosMsgTransporter<double>());} else
+      if (name == "int8") { return ti->addProtocol(ORO_ROS_PROTOCOL_ID, new RosMsgTransporter<int8_t>());} else
+      if (name == "int16") { return ti->addProtocol(ORO_ROS_PROTOCOL_ID, new RosMsgTransporter<int16_t>());} else
+      if (name == "int32") { return ti->addProtocol(ORO_ROS_PROTOCOL_ID, new RosMsgTransporter<int32_t>());} else
+      if (name == "int64") { return ti->addProtocol(ORO_ROS_PROTOCOL_ID, new RosMsgTransporter<int64_t>());} else
+      if (name == "string") { return ti->addProtocol(ORO_ROS_PROTOCOL_ID, new RosMsgTransporter<std::string>());} else
+      if (name == "rt_string") { return ti->addProtocol(ORO_ROS_PROTOCOL_ID, new RosMsgTransporter<RTT::rt_string>());} else
+      if (name == "time") { return ti->addProtocol(ORO_ROS_PROTOCOL_ID, new RosMsgTransporter<ros::Time>());} else
+      if (name == "uint8") { return ti->addProtocol(ORO_ROS_PROTOCOL_ID, new RosMsgTransporter<uint8_t>());} else
+      if (name == "uint16") { return ti->addProtocol(ORO_ROS_PROTOCOL_ID, new RosMsgTransporter<uint16_t>());} else
+      if (name == "uint32") { return ti->addProtocol(ORO_ROS_PROTOCOL_ID, new RosMsgTransporter<uint32_t>());} else
+      if (name == "uint64") { return ti->addProtocol(ORO_ROS_PROTOCOL_ID, new RosMsgTransporter<uint64_t>());} else
+      { }
+      return false;
+    }
+
+    std::string getTransportName() const {
+        return "ros";
+    }
+
+    std::string getTypekitName() const {
+        return "ros-primitives";
+    }
+    std::string getName() const {
+        return "rtt-ros-primitives-transport";
+    }
+
+  };
+}
+
+ORO_TYPEKIT_PLUGIN( rtt_std_msgs::ROSPrimitivesPlugin )

--- a/typekits/rtt_std_msgs/src/ros_primitives_transport_plugin.cpp
+++ b/typekits/rtt_std_msgs/src/ros_primitives_transport_plugin.cpp
@@ -18,16 +18,32 @@
 #include <std_msgs/Time.h>
 #include <ros/time.h>
 
+#include <std_msgs/vector_multi_array_adapter.h>
+
 #include <rtt_roscomm/rtt_rostopic_ros_msg_transporter.hpp>
 #include <rtt_roscomm/rtt_rostopic.h>
 #include <rtt/types/TransportPlugin.hpp>
 #include <rtt/types/TypekitPlugin.hpp>
 #include <rtt/rt_string.hpp>
 
-
 // There are no message_traits for ros::Time and ros::Duration, so we define it here.
 STD_MSGS_DEFINE_BUILTIN_TRAITS(::ros::Duration, Duration, 0x3e286caf4241d664ULL, 0xe55f3ad380e2ae46ULL)
 STD_MSGS_DEFINE_BUILTIN_TRAITS(::ros::Time, Time, 0xcd7166c74c552c31ULL, 0x1fbcc2fe5a7bc289ULL)
+
+// Adapt std::vector<double> to std_msgs/Float64MultiArray
+namespace rtt_roscomm {
+
+  template <class ContainerAllocator>
+  struct RosMessageAdapter<std::vector<double, ContainerAllocator> >
+  {
+    typedef std::vector<double, ContainerAllocator> OrocosType;
+    typedef std_msgs::VectorMultiArrayAdapter<double, ContainerAllocator> RosType;
+    static RosType toRos(const OrocosType &t) { return RosType(t); }
+    static const OrocosType &fromRos(const RosType &t) { return *t; }
+  };
+
+} // namespace rtt_roscomm
+
 
 namespace rtt_std_msgs {
   using namespace RTT;
@@ -38,6 +54,7 @@ namespace rtt_std_msgs {
   {
     bool registerTransport(std::string name, types::TypeInfo* ti)
     {
+      if (name == "array") { return ti->addProtocol(ORO_ROS_PROTOCOL_ID, new RosMsgTransporter<std::vector<double> >());} else
       if (name == "bool") { return ti->addProtocol(ORO_ROS_PROTOCOL_ID, new RosMsgTransporter<bool>());} else
       if (name == "duration") { return ti->addProtocol(ORO_ROS_PROTOCOL_ID, new RosMsgTransporter<ros::Duration>());} else
       if (name == "float32") { return ti->addProtocol(ORO_ROS_PROTOCOL_ID, new RosMsgTransporter<float>());} else


### PR DESCRIPTION
Backport of https://github.com/orocos/rtt_ros_integration/pull/83 to indigo-devel (and jade-devel). As the patch is fully API compatible and ABI-compatibility should not be an issue for transport plugins, there is no reason to not release it for ROS indigo and jade, too. Also included some earlier patches for package `rtt_roscomm_tests` to resolve merge conflicts.