### PR TITLE
rtt_dynamic_reconfigure: report updated property values in the service response (indigo-devel)

### DIFF
--- a/rtt_dynamic_reconfigure/include/orocos/rtt_dynamic_reconfigure/auto_config.h
+++ b/rtt_dynamic_reconfigure/include/orocos/rtt_dynamic_reconfigure/auto_config.h
@@ -119,8 +119,8 @@ struct dynamic_reconfigure_traits<AutoConfig> {
     static const bool canRefresh = true;
     static void refreshDescription(const ServerType *server) { AutoConfig::__refreshDescription__(server); }
 
-    static void toMessage(AutoConfig &config, dynamic_reconfigure::Config &message, const ServerType *server) { config.__toMessage__(message); }
-    static void fromMessage(AutoConfig &config, dynamic_reconfigure::Config &message, const ServerType *server) { config.__fromMessage__(message, config); }
+    static void toMessage(AutoConfig &config, dynamic_reconfigure::Config &message, const ServerType *) { config.__toMessage__(message); }
+    static void fromMessage(AutoConfig &config, dynamic_reconfigure::Config &message, const ServerType *server) { config.__fromMessage__(message, server->getConfig()); }
     static void clamp(AutoConfig &config, const ServerType *server) { config.__clamp__(server); }
 
     static RTT::internal::AssignableDataSource<RTT::PropertyBag>::shared_ptr getDataSource(AutoConfig &config, const ServerType *) {

--- a/rtt_dynamic_reconfigure/include/orocos/rtt_dynamic_reconfigure/server.h
+++ b/rtt_dynamic_reconfigure/include/orocos/rtt_dynamic_reconfigure/server.h
@@ -63,7 +63,7 @@
 namespace rtt_dynamic_reconfigure {
 
 template <class ConfigType> class Server;
-typedef bool (UpdateCallbackSignature)(const RTT::PropertyBag &source, uint32_t level);
+typedef bool (UpdateCallbackSignature)(RTT::PropertyBag &bag, uint32_t level);
 typedef void (NotifyCallbackSignature)(uint32_t level);
 
 /**
@@ -607,7 +607,7 @@ private:
         if (!updater()->propertiesFromConfig(new_config, level, bag)) return false;
         if (!update_callback_.ready() || !update_callback_(bag, level)) return false;
         if (notify_callback_.ready()) notify_callback_(level);
-        updater()->configFromProperties(new_config, *(getOwner()->properties()));
+        updater()->configFromProperties(new_config, bag);
 
         updateConfigInternal(new_config);
         new_config.__toMessage__(rsp.config);
@@ -627,9 +627,9 @@ private:
             update_pub_.publish(msg);
     }
 
-    bool updatePropertiesDefaultImpl(const RTT::PropertyBag &source, uint32_t)
+    bool updatePropertiesDefaultImpl(RTT::PropertyBag &bag, uint32_t)
     {
-        return RTT::updateProperties(*(getOwner()->properties()), source);
+        return RTT::updateProperties(*(getOwner()->properties()), bag);
     }
 };
 

--- a/rtt_dynamic_reconfigure/include/orocos/rtt_dynamic_reconfigure/server.h
+++ b/rtt_dynamic_reconfigure/include/orocos/rtt_dynamic_reconfigure/server.h
@@ -64,6 +64,7 @@ namespace rtt_dynamic_reconfigure {
 
 template <class ConfigType> class Server;
 typedef bool (UpdateCallbackSignature)(RTT::PropertyBag &bag, uint32_t level);
+typedef bool (UpdateCallbackConstSignature)(const RTT::PropertyBag &bag, uint32_t level);
 typedef void (NotifyCallbackSignature)(uint32_t level);
 
 /**
@@ -171,6 +172,9 @@ namespace {
   };
 }
 
+// Forward declaration of class DynamicReconfigureTestComponent
+class DynamicReconfigureTestComponent;
+
 /**
  * The Server<ConfigType> class implements a dynamic_reconfigure server as an RTT service.
  * It provides a similar API than the pure cpp dynamic_reconfigure server implemented in the <a href="http://wiki.ros.org/dynamic_reconfigure">dynamic_reconfigure</a> package.
@@ -198,8 +202,9 @@ private:
     bool initialized_;
 
     RTT::OperationCaller<UpdateCallbackSignature> update_callback_;
+    RTT::OperationCaller<UpdateCallbackConstSignature> update_callback_const_;
+    RTT::Operation<UpdateCallbackConstSignature> update_callback_default_impl_;
     RTT::OperationCaller<NotifyCallbackSignature> notify_callback_;
-    RTT::Operation<UpdateCallbackSignature> update_callback_default_impl_;
 
 public:
     /**
@@ -478,9 +483,9 @@ public:
         // RTT 2.9 and above already checks the caller thread internally and therefore does not require this hack.
         //
         RTT::base::OperationCallerBase<UpdateCallbackSignature>::shared_ptr update_callback_impl = update_callback_.getOperationCallerImpl();
-        if (update_callback_impl && update_callback_impl->isSend()) {
+        if (update_callback_impl) {
             RTT::ExecutionEngine *engine = update_callback_impl->getMessageProcessor();
-            if (engine && engine->getThread() && engine->getThread()->isSelf()) {
+            if (update_callback_impl->isSend() && engine && engine->getThread() && engine->getThread()->isSelf()) {
                 RTT::Logger::In in(this->getOwner()->getName() + "." + this->getName());
                 RTT::log(RTT::Debug) << "calling my own updateProperties operation from refresh()" << RTT::endlog();
                 update_callback_impl.reset(update_callback_impl->cloneI(engine));
@@ -489,10 +494,22 @@ public:
                 update_callback_(init_config, ~0);
             }
         }
+        RTT::base::OperationCallerBase<UpdateCallbackConstSignature>::shared_ptr update_callback_const_impl = update_callback_const_.getOperationCallerImpl();
+        if (update_callback_const_impl) {
+            RTT::ExecutionEngine *engine = update_callback_const_impl->getMessageProcessor();
+            if (update_callback_const_impl->isSend() && engine && engine->getThread() && engine->getThread()->isSelf()) {
+                RTT::Logger::In in(this->getOwner()->getName() + "." + this->getName());
+                RTT::log(RTT::Debug) << "calling my own updateProperties operation from refresh()" << RTT::endlog();
+                update_callback_const_impl.reset(update_callback_const_impl->cloneI(engine));
+                update_callback_const_impl->call(init_config, ~0);
+            } else {
+                update_callback_const_(init_config, ~0);
+            }
+        }
         RTT::base::OperationCallerBase<NotifyCallbackSignature>::shared_ptr notify_callback_impl = notify_callback_.getOperationCallerImpl();
-        if (notify_callback_impl && notify_callback_impl->isSend()) {
+        if (notify_callback_impl) {
             RTT::ExecutionEngine *engine = notify_callback_impl->getMessageProcessor();
-            if (engine && engine->getThread() && engine->getThread()->isSelf()) {
+            if (notify_callback_impl->isSend() && engine && engine->getThread() && engine->getThread()->isSelf()) {
                 RTT::Logger::In in(this->getOwner()->getName() + "." + this->getName());
                 RTT::log(RTT::Debug) << "calling my own notifyPropertiesUpdate operation from refresh()" << RTT::endlog();
                 notify_callback_impl.reset(notify_callback_impl->cloneI(engine));
@@ -502,8 +519,14 @@ public:
             }
         }
 #else
-        update_callback_(init_config, ~0);
-        if (notify_callback_.ready()) notify_callback_(~0);
+        if (update_callback_.ready()) {
+            update_callback_(init_config, ~0);
+        } else if (update_callback_const_.ready()) {
+            update_callback_const_(init_config, ~0);
+        }
+        if (notify_callback_.ready()) {
+            notify_callback_(~0);
+        }
 #endif
 
         updateConfigInternal(config_);
@@ -569,19 +592,25 @@ private:
         if (updater) setUpdater(updater);
 
         // check if owner provides the updateProperties operation
-        if (getOwner() && getOwner()->provides()->hasOperation("updateProperties")) {
-            update_callback_ = getOwner()->provides()->getLocalOperation("updateProperties");
+        if (getOwner() && getOwner()->provides()->hasMember("updateProperties")) {
+            RTT::OperationInterfacePart *op = getOwner()->provides()->getPart("updateProperties");
+            if (boost::dynamic_pointer_cast< RTT::base::OperationCallerBase<UpdateCallbackSignature> >(op->getLocalOperation())) {
+                update_callback_ = op;
+            } else {
+                update_callback_const_ = op;
+            }
         } else {
-            update_callback_ = update_callback_default_impl_.getOperationCaller();
+            update_callback_const_ = update_callback_default_impl_.getOperationCaller();
         }
 
         // check if owner provides the notifyPropertiesUpdate operation
-        if (getOwner() && getOwner()->provides()->hasOperation("notifyPropertiesUpdate")) {
-            notify_callback_ = getOwner()->provides()->getLocalOperation("notifyPropertiesUpdate");
+        if (getOwner() && getOwner()->provides()->hasMember("notifyPropertiesUpdate")) {
+            notify_callback_ = getOwner()->provides()->getPart("notifyPropertiesUpdate");
         }
 
         // update_callback_ and notify_callback_ are called from the ROS spinner thread -> set GlobalEngine as caller engine
         update_callback_.setCaller(RTT::internal::GlobalEngine::Instance());
+        update_callback_const_.setCaller(RTT::internal::GlobalEngine::Instance());
         notify_callback_.setCaller(RTT::internal::GlobalEngine::Instance());
 
         // refresh once
@@ -593,6 +622,7 @@ private:
         descr_pub_.publish(getDescriptionMessage());
     }
 
+    friend class DynamicReconfigureTestComponent;
     bool setConfigCallback(dynamic_reconfigure::Reconfigure::Request &req,
                            dynamic_reconfigure::Reconfigure::Response &rsp)
     {
@@ -605,9 +635,15 @@ private:
 
         RTT::PropertyBag bag;
         if (!updater()->propertiesFromConfig(new_config, level, bag)) return false;
-        if (!update_callback_.ready() || !update_callback_(bag, level)) return false;
+        if (update_callback_.ready()) {
+            if (!update_callback_(bag, level)) return false;
+            updater()->configFromProperties(new_config, bag);
+        } else if (update_callback_const_.ready()) {
+            if (!update_callback_const_(bag, level)) return false;
+        } else {
+            return false;
+        }
         if (notify_callback_.ready()) notify_callback_(level);
-        updater()->configFromProperties(new_config, bag);
 
         updateConfigInternal(new_config);
         new_config.__toMessage__(rsp.config);
@@ -627,7 +663,7 @@ private:
             update_pub_.publish(msg);
     }
 
-    bool updatePropertiesDefaultImpl(RTT::PropertyBag &bag, uint32_t)
+    bool updatePropertiesDefaultImpl(const RTT::PropertyBag &bag, uint32_t)
     {
         return RTT::updateProperties(*(getOwner()->properties()), bag);
     }

--- a/rtt_dynamic_reconfigure/include/orocos/rtt_dynamic_reconfigure/server.h
+++ b/rtt_dynamic_reconfigure/include/orocos/rtt_dynamic_reconfigure/server.h
@@ -607,6 +607,7 @@ private:
         if (!updater()->propertiesFromConfig(new_config, level, bag)) return false;
         if (!update_callback_.ready() || !update_callback_(bag, level)) return false;
         if (notify_callback_.ready()) notify_callback_(level);
+        updater()->configFromProperties(new_config, *(getOwner()->properties()));
 
         updateConfigInternal(new_config);
         new_config.__toMessage__(rsp.config);

--- a/rtt_dynamic_reconfigure/include/orocos/rtt_dynamic_reconfigure/server.h
+++ b/rtt_dynamic_reconfigure/include/orocos/rtt_dynamic_reconfigure/server.h
@@ -129,7 +129,7 @@ struct dynamic_reconfigure_traits {
     /**
      * Convert an instance of ConfigType to a dynamic_reconfigure::Config message
      *
-     * \param config referencte to the ConfigType instance to be read
+     * \param config reference to the ConfigType instance to be read
      * \param message reference to the Config message to be filled
      * \param server pointer to the rtt_dynamic_reconfigure server instance (only used for AutoConfig)
      */
@@ -138,7 +138,7 @@ struct dynamic_reconfigure_traits {
     /**
      * Convert a dynamic_reconfigure::Config message to an instance of ConfigType
      *
-     * \param config referencte to the ConfigType instance to be filled
+     * \param config reference to the ConfigType instance to be filled
      * \param message reference to the Config message to be read
      * \param server pointer to the rtt_dynamic_reconfigure server instance (only used for AutoConfig)
      */
@@ -241,6 +241,13 @@ public:
     virtual ~Server() {
         shutdown();
     }
+
+    /**
+     * Get the current configuration parameters
+     *
+     * \return a const reference to the ConfigType instance holding the current values
+     */
+    const ConfigType &getConfig() const { return config_; }
 
     /**
      * Update the config from an instance of ConfigType

--- a/tests/rtt_dynamic_reconfigure_tests/test/rtt_dynamic_reconfigure_tests.cpp
+++ b/tests/rtt_dynamic_reconfigure_tests/test/rtt_dynamic_reconfigure_tests.cpp
@@ -138,6 +138,94 @@ TEST_F(DynamicReconfigureTest, MinMaxDefault)
     EXPECT_EQ(5.0,  *(dflt.getPropertyType<double>("non_existent")));
 }
 
+TEST_F(DynamicReconfigureTest, DefaultUpdateCallback)
+{
+  // load test_reconfigure service
+  ASSERT_TRUE(tc.loadService("reconfigure"));
+  ASSERT_TRUE(tc.provides()->hasService("reconfigure"));
+
+  // check that no user callback has been called during service construction
+  EXPECT_FALSE(tc.updatePropertiesCalled);
+  EXPECT_FALSE(tc.updatePropertiesConstCalled);
+  EXPECT_FALSE(tc.notifyPropertiesUpdateCalled);
+
+  // check actual callback
+  dynamic_reconfigure::Reconfigure reconfigure;
+  EXPECT_TRUE(tc.setConfigCallback("reconfigure", reconfigure.request, reconfigure.response));
+  EXPECT_FALSE(tc.updatePropertiesCalled);
+  EXPECT_FALSE(tc.updatePropertiesConstCalled);
+  EXPECT_FALSE(tc.notifyPropertiesUpdateCalled);
+}
+
+TEST_F(DynamicReconfigureTest, UpdatePropertiesCallback)
+{
+  // add updateProperties operation
+  tc.addOperation("updateProperties", &DynamicReconfigureTestComponent::updateProperties, &tc);
+
+  // load test_reconfigure service
+  ASSERT_TRUE(tc.loadService("reconfigure"));
+  ASSERT_TRUE(tc.provides()->hasService("reconfigure"));
+
+  // check that updateProperties callback has been called during service construction
+  EXPECT_TRUE(tc.updatePropertiesCalled);
+  EXPECT_FALSE(tc.updatePropertiesConstCalled);
+  EXPECT_FALSE(tc.notifyPropertiesUpdateCalled);
+  tc.updatePropertiesCalled = false;
+
+  // check actual callback
+  dynamic_reconfigure::Reconfigure reconfigure;
+  EXPECT_TRUE(tc.setConfigCallback("reconfigure", reconfigure.request, reconfigure.response));
+  EXPECT_TRUE(tc.updatePropertiesCalled);
+  EXPECT_FALSE(tc.updatePropertiesConstCalled);
+  EXPECT_FALSE(tc.notifyPropertiesUpdateCalled);
+}
+
+TEST_F(DynamicReconfigureTest, UpdatePropertiesConstCallback)
+{
+  // add updateProperties operation
+  tc.addOperation("updateProperties", &DynamicReconfigureTestComponent::updatePropertiesConst, &tc);
+
+  // load test_reconfigure service
+  ASSERT_TRUE(tc.loadService("reconfigure"));
+  ASSERT_TRUE(tc.provides()->hasService("reconfigure"));
+
+  // check that updatePropertiesConst callback has been called during service construction
+  EXPECT_FALSE(tc.updatePropertiesCalled);
+  EXPECT_TRUE(tc.updatePropertiesConstCalled);
+  EXPECT_FALSE(tc.notifyPropertiesUpdateCalled);
+  tc.updatePropertiesConstCalled = false;
+
+  // check actual callback
+  dynamic_reconfigure::Reconfigure reconfigure;
+  EXPECT_TRUE(tc.setConfigCallback("reconfigure", reconfigure.request, reconfigure.response));
+  EXPECT_FALSE(tc.updatePropertiesCalled);
+  EXPECT_TRUE(tc.updatePropertiesConstCalled);
+  EXPECT_FALSE(tc.notifyPropertiesUpdateCalled);
+}
+
+TEST_F(DynamicReconfigureTest, NotifyPropertiesUpdateCallback)
+{
+  // add updateProperties operation
+  tc.addOperation("notifyPropertiesUpdate", &DynamicReconfigureTestComponent::notifyPropertiesUpdate, &tc);
+
+  // load test_reconfigure service
+  ASSERT_TRUE(tc.loadService("reconfigure"));
+  ASSERT_TRUE(tc.provides()->hasService("reconfigure"));
+
+  // check that notifyPropertiesUpdate callback has been called during service construction
+  EXPECT_FALSE(tc.updatePropertiesCalled);
+  EXPECT_FALSE(tc.updatePropertiesConstCalled);
+  EXPECT_TRUE(tc.notifyPropertiesUpdateCalled);
+  tc.notifyPropertiesUpdateCalled = false;
+
+  // check actual callback
+  dynamic_reconfigure::Reconfigure reconfigure;
+  EXPECT_TRUE(tc.setConfigCallback("reconfigure", reconfigure.request, reconfigure.response));
+  EXPECT_FALSE(tc.updatePropertiesCalled);
+  EXPECT_FALSE(tc.updatePropertiesConstCalled);
+  EXPECT_TRUE(tc.notifyPropertiesUpdateCalled);
+}
+
 TEST_F(DynamicReconfigureTest, AutoConfig)
 {
     // load test_reconfigure service

--- a/tests/rtt_dynamic_reconfigure_tests/test/test_component.cpp
+++ b/tests/rtt_dynamic_reconfigure_tests/test/test_component.cpp
@@ -8,4 +8,5 @@
 #include <rtt/Component.hpp>
 #include "test_component.hpp"
 
+using namespace rtt_dynamic_reconfigure;
 ORO_CREATE_COMPONENT(DynamicReconfigureTestComponent)


### PR DESCRIPTION
This is an improved version of https://github.com/orocos/rtt_ros_integration/pull/81 that does not break backwards-compatibility to existing components that implement a custom `bool updateProperties(const PropertyBag &, uint32_t level)` callback operation. It therefore can be merge to indigo-devel and released into ROS indigo and jade.

From #81:
> The user can provide a updateProperties(bag, level) operation that replaces the default implementation. Until now it was not possible to change values in the source bag and report the updated values back to the client in the service response. This missing functionality is implemented by this PR.

Also added basic unit tests for custom user callbacks.