### PR TITLE
rtt_kdl_conversions: removed operations for deprecated functions

### DIFF
--- a/typekits/rtt_kdl_conversions/kdl_conversions-types.cpp
+++ b/typekits/rtt_kdl_conversions/kdl_conversions-types.cpp
@@ -31,10 +31,6 @@ namespace KDL
           gs->provides("KDL")->addOperation("vectorKDLToMsg",&tf::vectorKDLToMsg);
           gs->provides("KDL")->addOperation("wrenchMsgToKDL",&tf::wrenchMsgToKDL);
           gs->provides("KDL")->addOperation("wrenchKDLToMsg",&tf::wrenchKDLToMsg);
-          gs->provides("KDL")->addOperation("TwistToMsg",&tf::TwistKDLToMsg);
-          gs->provides("KDL")->addOperation("MsgToTwist",&tf::TwistMsgToKDL);
-          gs->provides("KDL")->addOperation("FrameToMsg",&tf::PoseKDLToMsg);
-          gs->provides("KDL")->addOperation("MsgToFrame",&tf::PoseMsgToKDL);
           return true;
       }
   };


### PR DESCRIPTION
The functions
- `TwistToMsg`
- `MsgToTwist`
- `FrameToMsg`
- `MsgToFrame`

have been deprecated in upstream package [kdl_conversions](http://wiki.ros.org/kdl_conversions) in https://github.com/ros/geometry/commit/9655977bf7b5e1ca9150014adf568389e3ecd595. It is about time to also remove it from the Orocos wrapper.