### PR TITLE
Simple action server

### DIFF
--- a/rtt_actionlib/README.md
+++ b/rtt_actionlib/README.md
@@ -154,17 +154,17 @@ It depends on EventPort callbacks so unable to function if component is not Runn
 ```cpp
 class Component : public TaskContext
 {
-	protected:
-		// Goal, Feedback, Result typedefs
-		ACTION_DEFINITION(ActionSpec);	
+    protected:
+        // Goal, Feedback, Result typedefs
+        ACTION_DEFINITION(ActionSpec);    
 
-	protected:
-		OrocosSimpleActionServer<ActionSpec> action_server;
+    protected:
+        OrocosSimpleActionServer<ActionSpec> action_server;
         // Current goal cache
         Goal goal;
 
-		// new pending goal is received
-		void newGoalHook(const Goal& pending_goal) {
+        // new pending goal is received
+        void newGoalHook(const Goal& pending_goal) {
             // check if goal is valid
             if (!isOk(pending_goal)) action_server.rejectPending(result);
             else { 
@@ -180,24 +180,24 @@ class Component : public TaskContext
         }
 
 
-	public:
+    public:
         Component(std::string const& name) : 
             action_server(this->provides())
         {
             // action server hook registration
-            action_server.setGoalHook(boost::bind(&AnimJointTrajectory::newGoalHook, this, _1));
-            action_server.setGoalHook(boost::bind(&AnimJointTrajectory::cancelGoalHook, this, _1));
+            action_server.setGoalHook(boost::bind(&SomeComponent::newGoalHook, this, _1));
+            action_server.setCancelHook(boost::bind(&SomeComponent::cancelGoalHook, this));
         }
 
-		bool updateHook() {
+        bool updateHook() {
             if (action_server.isActive()) {
                 // pursue goal
             }
         }
 
-		void stopHook() {
+        void stopHook() {
             action_server.abortActive(result);
-            action_server.rejectPending(result);
+            action_server.rejectPending(Result());
         }
 };
 ```
@@ -205,7 +205,7 @@ class Component : public TaskContext
 Alternatively goal state changes can be monitored in `updateHook()`:
 
 ```cpp
-		bool updateHook() {
+        bool updateHook() {
             if (action_server.isPending()) {
                 if (! isOk(getPendingGoal())) rejectPending(Result());
                 else {

--- a/rtt_actionlib/README.md
+++ b/rtt_actionlib/README.md
@@ -159,7 +159,7 @@ class Component : public TaskContext
         ACTION_DEFINITION(ActionSpec);    
 
     protected:
-        OrocosSimpleActionServer<ActionSpec> action_server;
+        RTTSimpleActionServer<ActionSpec> action_server;
         // Current goal cache
         Goal goal;
 

--- a/rtt_actionlib/include/rtt_actionlib/rtt_simple_action_server.h
+++ b/rtt_actionlib/include/rtt_actionlib/rtt_simple_action_server.h
@@ -78,9 +78,9 @@ template <class ActionSpec> class RTTSimpleActionServer
 		}
 
 		/**
-		* Check, if active goal is being preemted.
+		* Check, if active goal is being preempted.
 		*/
-		bool isPreemting() const {
+		bool isPreempting() const {
 			return goal_active.isValid() && goal_active.getGoalStatus().status == actionlib_msgs::GoalStatus::PREEMPTING;
 		}
 

--- a/rtt_actionlib/include/rtt_actionlib/rtt_simple_action_server.h
+++ b/rtt_actionlib/include/rtt_actionlib/rtt_simple_action_server.h
@@ -283,7 +283,7 @@ template <class ActionSpec> void RTTSimpleActionServer<ActionSpec>::cancelCallba
 		case actionlib_msgs::GoalStatus::RECALLING:
 			if (goal_active == gh) {
 				if (cancelGoalHook) cancelGoalHook();
-				cancelActive(Result(), "Active goal is canceled by client request.");
+				// cancelActive(Result(), "Active goal is canceled by client request.");
 			}
 			else if (goal_pending == gh) {
 				gh.setCanceled(Result(), "Pending goal is canceled by client request.");

--- a/rtt_actionlib/include/rtt_actionlib/rtt_simple_action_server.h
+++ b/rtt_actionlib/include/rtt_actionlib/rtt_simple_action_server.h
@@ -1,5 +1,5 @@
-#ifndef  OROCOS_SIMPLE_ACTION_SERVER_HPP
-#define  OROCOS_SIMPLE_ACTION_SERVER_HPP
+#ifndef  RTT_SIMPLE_ACTION_SERVER_HPP
+#define  RTT_SIMPLE_ACTION_SERVER_HPP
 
 #include <stdexcept>
 #include <boost/bind.hpp>
@@ -96,7 +96,8 @@ template <class ActionSpec> class RTTSimpleActionServer
 		*/
 		boost::shared_ptr<const Goal> getActiveGoal() const {
 			if (isActive()) return goal_active.getGoal();
-			else return nullptr;
+			else return boost::shared_ptr<const Goal>(); // return NULL
+			// else nullptr;
 		}
 
 		/**
@@ -104,7 +105,8 @@ template <class ActionSpec> class RTTSimpleActionServer
 		 **/
 		boost::shared_ptr<const Goal> getPendingGoal() const {
 			if (isPending()) return goal_pending.getGoal();
-			else return nullptr;
+			else return boost::shared_ptr<const Goal>(); // return NULL
+			// else nullptr;
 		}
 
 		/**
@@ -297,4 +299,4 @@ template <class ActionSpec> void RTTSimpleActionServer<ActionSpec>::cancelCallba
 
 } // namespace rtt_actionlib
 
-#endif  /*SIMPLE_ACTION_SERVER_HPP*/
+#endif  /*RTT_SIMPLE_ACTION_SERVER_HPP*/

--- a/rtt_actionlib/include/rtt_actionlib/rtt_simple_action_server.h
+++ b/rtt_actionlib/include/rtt_actionlib/rtt_simple_action_server.h
@@ -7,7 +7,7 @@
 
 #include <actionlib/server/action_server.h>
 #include <actionlib/action_definition.h>
-#include <orocos/rtt_actionlib/rtt_action_server.h>
+#include <rtt_actionlib/rtt_action_server.h>
 
 namespace rtt_actionlib {
 

--- a/rtt_actionlib/include/rtt_actionlib/rtt_simple_action_server.h
+++ b/rtt_actionlib/include/rtt_actionlib/rtt_simple_action_server.h
@@ -20,7 +20,7 @@ template <class ActionSpec> class RTTSimpleActionServer
 		ACTION_DEFINITION(ActionSpec);	
 
 	protected:
-		rtt_actionlib::RTTActionServer<ActionSpec> action_server;
+		RTTActionServer<ActionSpec> action_server;
 		GoalHandle goal_active;
 		GoalHandle goal_pending;
 

--- a/rtt_actionlib/include/rtt_actionlib/rtt_simple_action_server.h
+++ b/rtt_actionlib/include/rtt_actionlib/rtt_simple_action_server.h
@@ -1,0 +1,300 @@
+#ifndef  OROCOS_SIMPLE_ACTION_SERVER_HPP
+#define  OROCOS_SIMPLE_ACTION_SERVER_HPP
+
+#include <stdexcept>
+#include <boost/bind.hpp>
+#include <boost/function.hpp>
+
+#include <actionlib/server/action_server.h>
+#include <actionlib/action_definition.h>
+#include <orocos/rtt_actionlib/rtt_action_server.h>
+
+namespace rtt_actionlib {
+
+template <class ActionSpec> class RTTSimpleActionServer 
+{
+	protected:
+		// GoalHandle
+		typedef actionlib::ServerGoalHandle<ActionSpec> GoalHandle;
+		// Goal, Feedback, Result typedefs
+		ACTION_DEFINITION(ActionSpec);	
+
+	protected:
+		rtt_actionlib::RTTActionServer<ActionSpec> action_server;
+		GoalHandle goal_active;
+		GoalHandle goal_pending;
+
+		// callbacks
+		boost::function<void(const Goal&)> newGoalHook;
+		boost::function<void()> cancelGoalHook;
+
+	protected:
+
+		void goalCallback(GoalHandle gh);
+		void cancelCallback(GoalHandle gh);
+
+	public:
+
+		/**
+		 * Create RTTSimpleActionServer in given Service.
+		 *
+		 * Create ports, register callbacks.
+		 * @param owner_service Pointer to owner service.
+		 */
+		RTTSimpleActionServer(boost::shared_ptr<RTT::Service> owner_service) 
+		{	
+			if (!owner_service) throw std::invalid_argument("RTTSimpleActionServer: owner pointer must be valid.");
+			action_server.addPorts(owner_service);
+			action_server.registerGoalCallback(boost::bind(&RTTSimpleActionServer<ActionSpec>::goalCallback, this, _1));
+			action_server.registerCancelCallback(boost::bind(&RTTSimpleActionServer<ActionSpec>::cancelCallback, this, _1));
+		}
+
+		/**
+		 * Check all connections.
+		 */
+		bool ready() { 
+			return action_server.ready(); 
+		}
+
+
+		/**
+		* Start action server in given TskContext.
+		* @param publish_feedback if true publish feedback periodically
+		*/
+		bool start(bool publish_feedback = false);
+
+		/**
+		* Stop action server.
+		*/
+		void shutdown() {
+			action_server.shutdown();
+		}
+
+		/**
+		* Check, if active goal is present.
+		*/
+		bool isActive() const {
+			return goal_active.isValid() && goal_active.getGoalStatus().status == actionlib_msgs::GoalStatus::ACTIVE;
+		}
+
+		/**
+		* Check, if active goal is being preemted.
+		*/
+		bool isPreemting() const {
+			return goal_active.isValid() && goal_active.getGoalStatus().status == actionlib_msgs::GoalStatus::PREEMPTING;
+		}
+
+		/**
+		* Check, if pending goal is present.
+		*/
+		bool isPending() const {
+			return goal_pending.isValid() && goal_pending.getGoalStatus().status == actionlib_msgs::GoalStatus::PENDING;
+		}
+
+		/** 
+		* Return pointer to active goal.
+		*/
+		boost::shared_ptr<const Goal> getActiveGoal() const {
+			if (isActive()) return goal_active.getGoal();
+			else return nullptr;
+		}
+
+		/**
+		 * Return pointer to pending goal.
+		 **/
+		boost::shared_ptr<const Goal> getPendingGoal() const {
+			if (isPending()) return goal_pending.getGoal();
+			else return nullptr;
+		}
+
+		/**
+		 * @brief Accept pending goal.
+		 * Accept pending goal, preempt the active goal with result if present. Do nothing if there is no pending goal.
+		 * @param result Result of the preemted active goal.
+		 * @return true if pending goal is accepted.
+		 **/
+		bool acceptPending(const Result& result, const std::string& msg = "");
+
+		/**
+		 * @brief Reject pending goal.
+		 * Reject pending goal with result, do nothing if there is no pending goal.
+		 * @param result Result of the rejected pending goal.
+		 * @return true if pending goal is rejected..
+		 **/
+		bool rejectPending(const Result& result, const std::string& msg = "");
+
+		/**
+		 * @brief Publish feedback on active goal.
+		 * Publish feedback on active goal, do nothing if there is no active goal.
+		 * @param feedback action feedback
+		 * @return true if active goal is present.
+		 **/
+		bool publishFeedback(const Feedback& feedpack);
+
+		/**
+		 * @brief Abort active goal.
+		 * Abort active goal with given result, do nothing if there is no active goal.
+		 * @param result Result of the aborted active goal.
+		 * @return true if active goal is aborted.
+		 **/
+		bool abortActive(const Result& result, const std::string& msg = "");
+
+		/**
+		 * @brief Cancel active goal.
+		 * Cancel active goal with given result, do nothing if there is no active goal.
+		 * @param result Result of the aborted active goal.
+		 * @return true if goal is been canceled.
+		 **/
+		bool cancelActive(const Result& result, const std::string& msg = "");
+
+		/**
+		 * @brief Succeed active goal.
+		 * Succeed active goal with given result, do nothing if there is no active goal.
+		 * @param result Result of the succeed active goal.
+		 * @return true if active goal is succeed.
+		 **/
+		bool succeedActive(const Result& result, const std::string& msg = "");
+
+		/**
+		 * @brief Setup goal hook.
+		 * @param newGoalHook A function, being called if new goal arrives.
+		 **/
+		void setGoalHook(boost::function< void(const Goal&)> _newGoalHook) {
+			newGoalHook = _newGoalHook;
+		}
+
+		/**
+		 * @brief Setup cancel hook.
+		 * @param cancelGoalHook A function, being called when active goal is canceled.
+		 **/
+		void setCancelHook(boost::function< void()> _cancelGoalHook) {
+			cancelGoalHook = _cancelGoalHook;
+		}
+};
+
+template <class ActionSpec> bool RTTSimpleActionServer<ActionSpec>::start(bool publish_feedback) 
+{
+	if (ready()) {
+		action_server.start();
+		if (publish_feedback) action_server.initialize();
+		return true;
+	}
+	else return false;
+}
+
+template <class ActionSpec> bool RTTSimpleActionServer<ActionSpec>::acceptPending(const Result& result, const std::string& msg)
+{
+	if (isPending()) {
+		if (goal_active.isValid()) {
+			switch (goal_active.getGoalStatus().status) {
+				case actionlib_msgs::GoalStatus::ACTIVE:
+				case actionlib_msgs::GoalStatus::PREEMPTING:
+					goal_active.setAborted(result, msg);
+					break;
+			}
+		}
+		goal_pending.setAccepted();
+		goal_active = goal_pending;
+		return isActive();
+	}
+	else {
+		// if pending is in RECALLING cancelHook perform necessary actions
+		return false;
+	}
+}
+
+template <class ActionSpec> bool RTTSimpleActionServer<ActionSpec>::rejectPending(const Result& result, const std::string& msg) 
+{
+	if (!goal_pending.isValid())  return false;
+	switch (goal_pending.getGoalStatus().status) {
+		case actionlib_msgs::GoalStatus::PENDING:
+		case actionlib_msgs::GoalStatus::RECALLING:
+			goal_pending.setRejected(result, msg);
+			return true;
+	}
+	return false;
+}
+
+template <class ActionSpec> bool RTTSimpleActionServer<ActionSpec>::publishFeedback(const Feedback& feedpack)
+{
+	if (!isActive()) return false;
+	goal_active.publishFeedback(feedpack);
+	return true;
+}
+
+template <class ActionSpec> bool RTTSimpleActionServer<ActionSpec>::abortActive(const Result& result, const std::string& msg)
+{
+	if (!goal_active.isValid())  return false;
+	switch (goal_active.getGoalStatus().status) {
+		case actionlib_msgs::GoalStatus::ACTIVE:
+		case actionlib_msgs::GoalStatus::PREEMPTING:
+			goal_active.setAborted(result, msg);
+			return true;
+	}
+	return false;
+}
+
+template <class ActionSpec> bool RTTSimpleActionServer<ActionSpec>::cancelActive(const Result& result, const std::string& msg)
+{
+	if (!goal_active.isValid()) return false;
+	switch (goal_active.getGoalStatus().status) {
+		case actionlib_msgs::GoalStatus::ACTIVE:
+		case actionlib_msgs::GoalStatus::PREEMPTING:
+			goal_active.setCanceled(result, msg);
+			return true;
+	}
+	return true;
+}
+
+template <class ActionSpec> bool RTTSimpleActionServer<ActionSpec>::succeedActive(const Result& result, const std::string& msg)
+{
+	if (!goal_active.isValid()) return false;
+	switch (goal_active.getGoalStatus().status) {
+		case actionlib_msgs::GoalStatus::ACTIVE:
+		case actionlib_msgs::GoalStatus::PREEMPTING:
+			goal_active.setSucceeded(result, msg);
+			return true;
+	}
+	return false;
+}
+
+template <class ActionSpec> void RTTSimpleActionServer<ActionSpec>::goalCallback(GoalHandle gh) 
+{
+	if (goal_pending.isValid()) {
+		switch (goal_pending.getGoalStatus().status) {
+			case actionlib_msgs::GoalStatus::PENDING:
+			case actionlib_msgs::GoalStatus::RECALLING:
+				goal_pending.setRejected(Result(), "Pending goal is replaced by new received goal.");
+				break;
+		}
+	}
+	goal_pending = gh;
+	if (isPending() && newGoalHook) {
+		newGoalHook(*goal_pending.getGoal());
+	}
+}
+
+template <class ActionSpec> void RTTSimpleActionServer<ActionSpec>::cancelCallback(GoalHandle gh) {
+	if (!gh.isValid()) return;
+	switch (gh.getGoalStatus().status) {
+		case actionlib_msgs::GoalStatus::ACTIVE:
+		case actionlib_msgs::GoalStatus::PREEMPTING:
+		case actionlib_msgs::GoalStatus::PENDING:
+		case actionlib_msgs::GoalStatus::RECALLING:
+			if (goal_active == gh) {
+				if (cancelGoalHook) cancelGoalHook();
+				cancelActive(Result(), "Active goal is canceled by client request.");
+			}
+			else if (goal_pending == gh) {
+				gh.setCanceled(Result(), "Pending goal is canceled by client request.");
+			}
+			else {
+				gh.setCanceled(Result(), "Unknown goal.");
+			}
+			break;
+	}
+}
+
+} // namespace rtt_actionlib
+
+#endif  /*SIMPLE_ACTION_SERVER_HPP*/


### PR DESCRIPTION
In our project we implemented the analog of ROS actionlib::SimpleActionServer. Unfortunately, its interface is different from ROS but it still hides all annoying checks of GoalHandle state.

Repository https://github.com/disRecord/rtt_ros_examples contains working usage examples.