### PR TITLE
Add RTT connection introspection support for ROS publisher and subscriber streams

### DIFF
--- a/rtt_roscomm/include/rtt_roscomm/rtt_rostopic_ros_msg_transporter.hpp
+++ b/rtt_roscomm/include/rtt_roscomm/rtt_rostopic_ros_msg_transporter.hpp
@@ -160,7 +160,19 @@ namespace rtt_roscomm {
     virtual bool inputReady() {
       return true;
     }
-    
+
+    virtual bool isRemoteElement() const {
+        return true;
+    }
+
+    virtual std::string getElementName() const {
+        return "RosPubChannelElement";
+    }
+
+    virtual std::string getRemoteURI() const {
+        return ros_node.getNamespace() + topicname;
+    }
+
     /** 
      * Create a data sample, this could be used to allocate the necessary memory
      * 
@@ -265,6 +277,18 @@ namespace rtt_roscomm {
 
     virtual bool inputReady() {
       return true;
+    }
+
+    virtual bool isRemoteElement() const {
+        return true;
+    }
+
+    virtual std::string getElementName() const {
+        return "RosSubChannelElement";
+    }
+
+    virtual std::string getRemoteURI() const {
+        return ros_node.getNamespace() + topicname;
     }
 
     /**

--- a/rtt_roscomm/include/rtt_roscomm/rtt_rostopic_ros_msg_transporter.hpp
+++ b/rtt_roscomm/include/rtt_roscomm/rtt_rostopic_ros_msg_transporter.hpp
@@ -170,7 +170,7 @@ namespace rtt_roscomm {
     }
 
     virtual std::string getRemoteURI() const {
-        return ros_node.getNamespace() + topicname;
+        return ros_pub.getTopic();
     }
 
     /** 
@@ -288,7 +288,7 @@ namespace rtt_roscomm {
     }
 
     virtual std::string getRemoteURI() const {
-        return ros_node.getNamespace() + topicname;
+        return ros_sub.getTopic();
     }
 
     /**


### PR DESCRIPTION
https://github.com/orocos-toolchain/rtt/pull/90 added support for connection introspection to RTT's data flow channel API. This PR extends the `RosPubChannelElement` and `RosSubChannelElement` specializations provided by the `rtt_roscomm` package with overwritten implementations of the added virtual base functions
- [ChannelElementBase::isRemoteElement()](https://github.com/orocos-toolchain/rtt/pull/90/files#diff-51b13774fd6d17869ba8eb2ba6588f7aR188),
- [ChannelElementBase::getRemoteURI()](https://github.com/orocos-toolchain/rtt/pull/90/files#diff-51b13774fd6d17869ba8eb2ba6588f7aR200) and
- [ChannelElementBase::getElementName()](https://github.com/orocos-toolchain/rtt/pull/90/files#diff-51b13774fd6d17869ba8eb2ba6588f7aR216).

There should be no problem to use this version of `rtt_roscomm` without https://github.com/orocos-toolchain/rtt/pull/90. The new methods will simply not be called.