### PR TITLE
rtt_roscomm: fix hard-coded path to python interpreter in shebang of create_boost_header.py

### DIFF
--- a/rtt_roscomm/CMakeLists.txt
+++ b/rtt_roscomm/CMakeLists.txt
@@ -45,8 +45,8 @@ install(
   DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}/orocos
 )
 
-# Install cmake macros
-install(PROGRAMS scripts/create_boost_header.py DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+# Install create_boost_header.py
+catkin_install_python(PROGRAMS scripts/create_boost_header.py DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 # Install template files
 install(DIRECTORY src/templates DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/src)

--- a/rtt_roscomm/scripts/create_boost_header.py
+++ b/rtt_roscomm/scripts/create_boost_header.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import sys
 
 import roslib


### PR DESCRIPTION
Required for system installations which use non-default Python interpreters installed in other locations than `/usr/bin/python` and especially for macOS with HomeBrew.