### PR TITLE
Declare loadROSService() methods as static to fix name clashes

### DIFF
--- a/rtt_ros/src/rtt_ros_service.cpp
+++ b/rtt_ros/src/rtt_ros_service.cpp
@@ -22,7 +22,7 @@
 
 #include <rtt_ros/rtt_ros.h>
 
-void loadROSService(){
+static void loadROSService(){
   RTT::Service::shared_ptr ros = RTT::internal::GlobalService::Instance()->provides("ros");
 
   ros->doc("RTT service for loading RTT plugins ");

--- a/rtt_roscomm/src/rtt_rosservice_registry_service.cpp
+++ b/rtt_roscomm/src/rtt_rosservice_registry_service.cpp
@@ -95,8 +95,9 @@ void ROSServiceRegistryService::listSrvs()
 std::map<std::string, boost::shared_ptr<ROSServiceProxyFactoryBase> > ROSServiceRegistryService::factories_;
 RTT::os::MutexRecursive ROSServiceRegistryService::factory_lock_;
 
-void loadROSServiceRegistryService()
+static void loadROSServiceRegistryService()
 {
+  // enforce instantiation of ROSServiceRegistryService singleton
   ROSServiceRegistryService::Instance();
 }
 

--- a/rtt_rosnode/src/ros_plugin.cpp
+++ b/rtt_rosnode/src/ros_plugin.cpp
@@ -36,7 +36,7 @@
 
 using namespace RTT;
 
-void loadROSService()
+static void loadROSService()
 {
   RTT::Service::shared_ptr ros = RTT::internal::GlobalService::Instance()->provides("ros");
 


### PR DESCRIPTION
Fixes #110:
> The global function loadROSService() in rtt_rosnode/src/ros_plugin.cpp added in 6ae4950 apparently overrides one with the same name residing in rtt_ros/src/rtt_ros_service.cpp (probably during linking).