### PR TITLE
rtt_rosclock: fixing isSelf segfault when using simclock with ownthread operation caller

### DIFF
--- a/rtt_rosclock/src/rtt_rosclock_sim_clock_activity.cpp
+++ b/rtt_rosclock/src/rtt_rosclock_sim_clock_activity.cpp
@@ -39,6 +39,7 @@
  *  - Integrated with rtt_rosclock package
  *********************************************************************/
 
+#include <rtt_rosclock/rtt_rosclock_sim_clock_thread.h>
 #include <rtt_rosclock/rtt_rosclock_sim_clock_activity.h>
 #include <rtt_rosclock/rtt_rosclock_sim_clock_activity_manager.h>
 
@@ -111,7 +112,7 @@ bool SimClockActivity::setCpuAffinity(unsigned cpu)
 
 RTT::os::ThreadInterface* SimClockActivity::thread()
 {
-  return 0;
+  return SimClockThread::GetInstance().get();
 }
 
 bool SimClockActivity::initialize()


### PR DESCRIPTION
In toolchain-2.9 if you try to call an operation on a component whose activity is the `SimClockActivity`, it tries to determine which thread to use. It calls `RTT::os::ThreadInterface::isSelf` with the value returned by the activity's thread, which is `NULL` without this patch.

```
#0  RTT::os::ThreadInterface::isSelf (this=0x0) at <<<REDACTED>>>/rtt/os/ThreadInterface.cpp:60
#1  0x00007fffca842920 in RTT::base::OperationCallerInterface::isSend (this=this@entry=0x7fff74346548) at <<<REDACTED>>>/rtt/base/OperationCallerInterface.cpp:38
#2  0x00007fffca81f92d in RTT::internal::LocalOperationCallerImpl<bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::call_impl<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (a1="base", this=<optimized out>)
    at <<<REDACTED>>>/rtt/internal/../internal/LocalOperationCaller.hpp:379
#3  RTT::internal::InvokerImpl<1, bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&), RTT::internal::LocalOperationCallerImpl<bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> >::call(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (this=0x7fff74346540, a1=...)
    at <<<REDACTED>>>/rtt/internal/../internal/Invoker.hpp:96
#4  0x00007fffca80c2ae in boost::_bi::list2<boost::_bi::value<bool (RTT::internal::InvokerBaseImpl<1, bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::*)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>, boost::_bi::value<boost::fusion::cons<RTT::base::OperationCallerBase<bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>*, boost::fusion::cons<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, boost::fusion::nil_> > > >::operator()<bool, bool (*)(bool (RTT::base::OperationCallerBase<bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::*)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&), boost::fusion::cons<RTT::base::OperationCallerBase<bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>*, boost::fusion::cons<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, boost::fusion::nil_> > const&), boost::_bi::list0>(boost::_bi::type<bool>, bool (*&)(bool (RTT::base::OperationCallerBase<bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::*)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&), boost::fusion::cons<RTT::base::OperationCallerBase<bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>*, boost::fusion::cons<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, boost::fusion::nil_> > const&), boost::_bi::list0&, long) (
    f=@0x7fff01cbddf0: 0x7fffca804500 <boost::fusion::invoke<bool (RTT::base::OperationCallerBase<bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::*)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&), boost::fusion::cons<RTT::base::OperationCallerBase<bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>*, boost::fusion::cons<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, boost::fusion::nil_> > >(bool (RTT::base::OperationCallerBase<bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::*)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&), boost::fusion::cons<RTT::base::OperationCallerBase<bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>*, boost::fusion::cons<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, boost::fusion::nil_> > const&)>, a=<synthetic pointer>, this=0x7fff01cbddf8) at /usr/include/boost/bind/bind.hpp:303
#5  boost::_bi::bind_t<bool, bool (*)(bool (RTT::base::OperationCallerBase<bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::*)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&), boost::fusion::cons<RTT::base::OperationCallerBase<bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>*, boost::fusion::cons<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, boost::fusion::nil_> > const&), boost::_bi::list2<boost::_bi::value<bool (RTT::internal::InvokerBaseImpl<1, bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::*)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>, boost::_bi::value<boost::fusion::cons<RTT::base::OperationCallerBase<bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>*, boost::fusion::cons<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, boost::fusion::nil_> > > > >::operator()() (this=0x7fff01cbddf0)
    at /usr/include/boost/bind/bind_template.hpp:20
#6  RTT::internal::RStore<bool>::exec<boost::_bi::bind_t<bool, bool (*)(bool (RTT::base::OperationCallerBase<bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::*)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&), boost::fusion::cons<RTT::base::OperationCallerBase<bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>*, boost::fusion::cons<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, boost::fusion::nil_> > const&), boost::_bi::list2<boost::_bi::value<bool (RTT::internal::InvokerBaseImpl<1, bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::*)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>, boost::_bi::value<boost::fusion::cons<RTT::base::OperationCallerBase<bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>*, boost::fusion::cons<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, boost::fusion::nil_> > > > > >(boost::_bi::bind_t<bool, bool (*)(bool (RTT::base::OperationCallerBase<bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::*)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&), boost::fusion::cons<RTT::base::OperationCallerBase<bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>*, boost::fusion::cons<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, boost::fusion::nil_> > const&), boost::_bi::list2<boost::_bi::value<bool (RTT::internal::InvokerBaseImpl<1, bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::*)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>, boost::_bi::value<boost::fusion::cons<RTT::base::OperationCallerBase<bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>*, boost::fusion::cons<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, boost::fusion::nil_> > > > >) (f=..., this=0x7fff74346630)
    at <<<REDACTED>>>/rtt/internal/BindStorage.hpp:157
#7  RTT::internal::FusedMCallDataSource<bool (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::evaluate() const (this=0x7fff74346600)
    at <<<REDACTED>>>/rtt/internal/FusedFunctorDataSource.hpp:305
#8  0x00007fffca84f381 in RTT::internal::AssignCommand<bool, bool>::execute (this=0x7fff74346760) at <<<REDACTED>>>/rtt/internal/AssignCommand.hpp:85
#9  0x00007fffca84ecf8 in RTT::internal::DataSourceCommand::get (this=0x7fff74346310) at <<<REDACTED>>>/rtt/internal/DataSourceCommand.cpp:63
#10 0x00007fffca84f10d in RTT::internal::DataSource<bool>::evaluate (this=<optimized out>) at <<<REDACTED>>>/rtt/internal/DataSource.inl:54
#11 0x00007fffca85ecc6 in RTT::internal::OperationCallerC::call (this=0x7fff743464d0) at <<<REDACTED>>>/rtt/internal/OperationCallerC.cpp:215
#12 0x00007ffef23ee4ab in __Operation_call (L=0x7fff742180e0) at <<<REDACTED>>>/rtt.cpp:1585
#13 Operation_call (L=0x7fff742180e0) at <<<REDACTED>>>/rtt.cpp:1631
#14 0x00007ffef38ac320 in ?? () from /usr/lib/x86_64-linux-gnu/liblua5.1.so.0
#15 0x00007ffef38b6e87 in ?? () from /usr/lib/x86_64-linux-gnu/liblua5.1.so.0
#16 0x00007ffef38ac77d in ?? () from /usr/lib/x86_64-linux-gnu/liblua5.1.so.0
#17 0x00007ffef38aba5e in ?? () from /usr/lib/x86_64-linux-gnu/liblua5.1.so.0
#18 0x00007ffef38ac8eb in ?? () from /usr/lib/x86_64-linux-gnu/liblua5.1.so.0
```