### PR TITLE
rtt_roscomm: fixed compilation of service plugins with Clang

### DIFF
--- a/rtt_roscomm/include/rtt_roscomm/rtt_rosservice_proxy.h
+++ b/rtt_roscomm/include/rtt_roscomm/rtt_rosservice_proxy.h
@@ -7,6 +7,9 @@
 #include <rtt/internal/GlobalEngine.hpp>
 #include <rtt/plugin/ServicePlugin.hpp>
 
+#include <boost/utility/enable_if.hpp>
+#include <boost/type_traits/is_void.hpp>
+
 //! Abstract ROS Service Proxy
 class ROSServiceProxyBase
 {
@@ -46,7 +49,9 @@ public:
 };
 
 template<class ROS_SERVICE_T, int variant = 0>
-struct ROSServiceServerOperationCallerWrapper;
+struct ROSServiceServerOperationCallerWrapper {
+  typedef void ProxyOperationCallerType;
+};
 
 // Default implementation of an OperationCaller that fowards ROS service calls to Orocos operations
 // that have the default bool(Request&, Response&) signature. You can add more variants of this class
@@ -66,7 +71,7 @@ struct ROSServiceServerOperationCallerWrapper<ROS_SERVICE_T,0> {
 template<class ROS_SERVICE_T, int variant = 0>
 class ROSServiceServerOperationCaller : public ROSServiceServerOperationCallerBase<ROS_SERVICE_T> {
 public:
-  using typename ROSServiceServerOperationCallerBase<ROS_SERVICE_T>::Ptr;
+  typedef typename ROSServiceServerOperationCallerBase<ROS_SERVICE_T>::Ptr Ptr;
 
   //! The wrapper type for this variant
   typedef ROSServiceServerOperationCallerWrapper<ROS_SERVICE_T, variant> Wrapper;
@@ -75,14 +80,7 @@ public:
   typedef typename Wrapper::ProxyOperationCallerType ProxyOperationCallerType;
   typedef boost::shared_ptr<ProxyOperationCallerType> ProxyOperationCallerTypePtr;
 
-  static Ptr connect(RTT::OperationInterfacePart* operation) {
-    ProxyOperationCallerTypePtr proxy_operation_caller
-        = boost::make_shared<ProxyOperationCallerType>(operation->getLocalOperation(), RTT::internal::GlobalEngine::Instance());
-    if (proxy_operation_caller->ready()) {
-      return Ptr(new ROSServiceServerOperationCaller<ROS_SERVICE_T, variant>(proxy_operation_caller));
-    }
-    return NextVariant<void>::connect(operation);
-  }
+  static Ptr connect(RTT::OperationInterfacePart* operation);
 
   virtual bool call(typename ROS_SERVICE_T::Request& request, typename ROS_SERVICE_T::Response& response) const {
     // Check if the operation caller is ready, and then call it.
@@ -91,32 +89,41 @@ public:
   }
 
 private:
-  template<typename Dummy> struct Void { typedef void type; };
-
-  template<typename R = void, typename Enabled = void> struct EnableIfHasNextVariant { };
-
-  template<typename R> struct EnableIfHasNextVariant<R,
-      typename Void<typename ROSServiceServerOperationCallerWrapper<ROS_SERVICE_T, variant + 1>::ProxyOperationCallerType>::type> {
-    typedef R type;
-  };
-
-  template<typename R = void, typename Enabled = void>
-  struct NextVariant {
-    static Ptr connect(RTT::OperationInterfacePart*) { return Ptr(); }
-  };
-
-  template<typename R>
-  struct NextVariant<R, typename EnableIfHasNextVariant<R>::type> {
-    static Ptr connect(RTT::OperationInterfacePart* operation) {
-      return ROSServiceServerOperationCaller<ROS_SERVICE_T, variant + 1>::connect(operation);
-    }
-  };
-
   ROSServiceServerOperationCaller(const boost::shared_ptr<ProxyOperationCallerType>& impl)
       : proxy_operation_caller_(impl) {}
 
   ProxyOperationCallerTypePtr proxy_operation_caller_;
 };
+
+namespace {
+
+template<class ROS_SERVICE_T, int variant, typename Enabled = void>
+struct ROSServiceServerOperationCallerWrapperNextVariant {
+  typedef typename ROSServiceServerOperationCallerBase<ROS_SERVICE_T>::Ptr Ptr;
+  static Ptr connect(RTT::OperationInterfacePart*) { return Ptr(); }
+};
+
+template<class ROS_SERVICE_T, int variant>
+struct ROSServiceServerOperationCallerWrapperNextVariant<ROS_SERVICE_T, variant,
+    typename boost::disable_if<boost::is_void<typename ROSServiceServerOperationCallerWrapper<ROS_SERVICE_T, variant + 1>::ProxyOperationCallerType> >::type> {
+  typedef typename ROSServiceServerOperationCallerBase<ROS_SERVICE_T>::Ptr Ptr;
+  static Ptr connect(RTT::OperationInterfacePart* operation) {
+    return ROSServiceServerOperationCaller<ROS_SERVICE_T, variant + 1>::connect(operation);
+  }
+};
+
+}
+
+template<class ROS_SERVICE_T, int variant>
+typename ROSServiceServerOperationCaller<ROS_SERVICE_T, variant>::Ptr
+ROSServiceServerOperationCaller<ROS_SERVICE_T, variant>::connect(RTT::OperationInterfacePart* operation) {
+  ProxyOperationCallerTypePtr proxy_operation_caller
+      = boost::make_shared<ProxyOperationCallerType>(operation->getLocalOperation(), RTT::internal::GlobalEngine::Instance());
+  if (proxy_operation_caller->ready()) {
+    return Ptr(new ROSServiceServerOperationCaller<ROS_SERVICE_T, variant>(proxy_operation_caller));
+  }
+  return ROSServiceServerOperationCallerWrapperNextVariant<ROS_SERVICE_T, variant>::connect(operation);
+}
 
 template<class ROS_SERVICE_T>
 class ROSServiceServerProxy : public ROSServiceServerProxyBase


### PR DESCRIPTION
Fixes a regression from https://github.com/orocos/rtt_ros_integration/pull/123, that caused build failures when compiling service plugins with Clang. Clang seems to handle SFINAE differently than gcc and compilation of generated service proxy plugins failed with errors like:

```cpp
In file included from rtt_diagnostic_msgs/diagnostic_msgs_service_proxies/rtt_rosservice_proxies.cpp:7:
rtt_roscomm/rtt_rosservice_proxy.h:99:30: error: implicit instantiation of undefined template 'ROSServiceServerOperationCallerWrapper<diagnostic_msgs::AddDiagnostics, 1>'
```