### PR TITLE
Fix rtt_actionlib simple action server

### DIFF
--- a/rtt_actionlib/include/rtt_actionlib/rtt_action_server.h
+++ b/rtt_actionlib/include/rtt_actionlib/rtt_action_server.h
@@ -70,6 +70,9 @@ namespace rtt_actionlib {
     //! Check if the server is ready to be started
     bool ready();
 
+    //! \brief Shutdown internal timer
+    void shutdown();
+
     //! \brief Set up status publishing timers
     virtual void initialize();
 
@@ -166,6 +169,12 @@ namespace rtt_actionlib {
     bool RTTActionServer<ActionSpec>::ready() 
     {
       return action_bridge_.allConnected();
+    }
+
+  template <class ActionSpec>
+    void RTTActionServer<ActionSpec>::shutdown()
+    {
+	status_timer_.killTimer(0);
     }
 
   template <class ActionSpec>

--- a/rtt_actionlib/include/rtt_actionlib/rtt_simple_action_server.h
+++ b/rtt_actionlib/include/rtt_actionlib/rtt_simple_action_server.h
@@ -58,10 +58,9 @@ template <class ActionSpec> class RTTSimpleActionServer
 
 
 		/**
-		* Start action server in given TskContext.
-		* @param publish_feedback if true publish feedback periodically
+		* Start action server in given TaskContext.
 		*/
-		bool start(bool publish_feedback = false);
+		bool start();
 
 		/**
 		* Stop action server.
@@ -174,11 +173,10 @@ template <class ActionSpec> class RTTSimpleActionServer
 		}
 };
 
-template <class ActionSpec> bool RTTSimpleActionServer<ActionSpec>::start(bool publish_feedback) 
+template <class ActionSpec> bool RTTSimpleActionServer<ActionSpec>::start()
 {
 	if (ready()) {
 		action_server.start();
-		if (publish_feedback) action_server.initialize();
 		return true;
 	}
 	else return false;


### PR DESCRIPTION
Add a shutdown method to `RTTActionServer`, so it is possible to stop the timer, and moreover to make RTTSimpleActionServer::shutdown compile.

Also remove the `publish_feedback` flag to `RTTSimpleActionServer::start`, since `RTTActionServer::initialize` will be called anyway by `RTTActionServer::start` (see [the source code of actionlib::ActionServerBase::start](https://github.com/ros/actionlib/blob/e9c6c0dc58dd44a2d4e81c20e9dbd1103f44a62b/include/actionlib/server/action_server_base.h#L194-L200))