### PR TITLE
Do not use ROS connection with rtt_rosclock::SimClockThread if time source is manual

### DIFF
--- a/rtt_rosclock/include/rtt_rosclock/rtt_rosclock_sim_clock_thread.h
+++ b/rtt_rosclock/include/rtt_rosclock/rtt_rosclock_sim_clock_thread.h
@@ -126,8 +126,6 @@ namespace rtt_rosclock {
     //! Keep running the thread loop if this is set to true
     bool process_callbacks_;
 
-    //! ROS NodeHandle for communication
-    ros::NodeHandle nh_;
     //! ROS /clock topic subscriber
     ros::Subscriber clock_subscriber_;
     //! Custom callback queue used in this thread

--- a/rtt_rosclock/src/rtt_rosclock_sim_clock_thread.cpp
+++ b/rtt_rosclock/src/rtt_rosclock_sim_clock_thread.cpp
@@ -220,6 +220,8 @@ bool SimClockThread::initialize()
   {
     case SIM_CLOCK_SOURCE_ROS_CLOCK_TOPIC:
       {
+        ros::NodeHandle nh;
+
         // Get /use_sim_time parameter from ROS
         bool use_sim_time = false;
         ros::param::get("/use_sim_time", use_sim_time);
@@ -239,7 +241,7 @@ bool SimClockThread::initialize()
         ros::SubscribeOptions ops = ros::SubscribeOptions::create<rosgraph_msgs::Clock>(
             "/clock", 1, boost::bind(&SimClockThread::clockMsgCallback, this, _1),
             ros::VoidConstPtr(), &callback_queue_);
-        clock_subscriber_ = nh_.subscribe(ops);
+        clock_subscriber_ = nh.subscribe(ops);
 
         // The loop needs to run in order to call the callback queue
         process_callbacks_ = true;


### PR DESCRIPTION
rtt_rosclock::SimClockThread used to instantiate a ros::NodeHandle event if the time source is `SIM_CLOCK_SOURCE_MANUAL`. This is a problem when one wants to write tests not relying on a ROS connection.

rtt_rosclock::SimClockThread now instantiate a ros::NodeHandle only if the time source is the /clock topic, and not the manual time source.