### PR TITLE
rtt_roscomm: update create_boost_header.py for Python3 compatibility

### DIFF
--- a/rtt_roscomm/scripts/create_boost_header.py
+++ b/rtt_roscomm/scripts/create_boost_header.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import sys
 
 import roslib
@@ -9,7 +13,7 @@ import genmsg
 from  roslib import packages,msgs
 import os
 
-from cStringIO import StringIO
+from io import StringIO
 
 import argparse
 
@@ -92,11 +96,11 @@ def generate_boost_serialization(package, msg_path, msg_type, boost_header_path)
     (output_dir,filename) = os.path.split(boost_header_path)
     try:
         os.makedirs(output_dir)
-    except OSError, e:
+    except OSError as e:
         pass
 
     f = open(boost_header_path, 'w')
-    print >> f, s.getvalue()
+    print(s.getvalue(), file=f)
 
     s.close()
 
@@ -115,7 +119,7 @@ def create_boost_headers(argv, stdout, stderr):
 if __name__ == "__main__":
     try:
         create_boost_headers(sys.argv, sys.stdout, sys.stderr)
-    except Exception, e:
+    except Exception as e:
         sys.stderr.write("Failed to generate boost headers: " + str(e))
         raise
         #sys.exit(1)


### PR DESCRIPTION
Required to build with Python version 3.

Thanks to [Python-Future](https://python-future.org/) the same script works with both versions, Python 2 and 3.