### PR TITLE
rtt_rosparam: add direct access to Ros parameters

### DIFF
--- a/rtt_rosparam/README.md
+++ b/rtt_rosparam/README.md
@@ -53,6 +53,7 @@ policy (see below).
 ##### Operations for getting single properties
 
 * **getParam(ros_name, rtt_name)** Get the ROS param **ros_name** and store it in the RTT property **rtt_name**. Use leaders like `~` and `/` for private and absolute resolution.
+* `getParam_type_(name)` Gets the value of a ROS param named `name`. The value returned is the default constructor if no `name` parameter can be found. Use leaders like `~` and `/` for private and absolute resolution.
 * **get(name ,policy)** Attempt to get the property named **name** (or populates the properties of a named RTT sub-service)
   from the ROS parameter namespace specified by **policy**.
 * **getRelative(name)**
@@ -63,6 +64,7 @@ policy (see below).
 ##### Operations for setting single properties
 
 * **setParam(ros_name, rtt_name)** Set the ROS param **ros_name** from the value in the RTT property **rtt_name**. Use leaders like `~` and `/` for private and absolute resolution.
+* `setParam_type(name, value)` Sets the value of the ROS param `name` to `value`. Use leaders like `~` and `/` for private and absolute resolution.
 * **set(name, policy)** Attempt to set the property named **name** (or stores the properties of a named RTT sub-service)
   in the ROS parameter namespace specified by **policy**.
 * **setRelative(name)**
@@ -135,7 +137,7 @@ class MyComponent : public RTT::TaskContext {
         all_params_found &= rosparam->getAbsolute("robot_description");
 
         // Get the ROS parameter "~publish_period"
-        all_params_found &= rosparam->getPrivate("publish_priod");
+        all_params_found &= rosparam->getPrivate("publish_period");
       }
       
       return all_params_found;

--- a/rtt_rosparam/include/rtt_rosparam/rosparam.h
+++ b/rtt_rosparam/include/rtt_rosparam/rosparam.h
@@ -15,6 +15,8 @@
 #define ADD_ROSPARAM_SERVICE_CONSTRUCTOR(return_type_str) \
   ,get##return_type_str("get"#return_type_str) \
   ,set##return_type_str("set"#return_type_str) \
+  ,getParam##return_type_str("getParam"#return_type_str) \
+  ,setParam##return_type_str("setParam"#return_type_str) \
   ,get##return_type_str##Relative ("get"#return_type_str"Relative") \
   ,set##return_type_str##Relative ("set"#return_type_str"Relative") \
   ,get##return_type_str##Absolute ("get"#return_type_str"Absolute") \
@@ -33,6 +35,8 @@
 #define ADD_ROSPARAM_OPERATION_CALLER(return_type_str) \
   this->addOperationCaller(get##return_type_str); \
   this->addOperationCaller(set##return_type_str); \
+  this->addOperationCaller(getParam##return_type_str); \
+  this->addOperationCaller(setParam##return_type_str); \
   this->addOperationCaller(get##return_type_str##Relative); \
   this->addOperationCaller(set##return_type_str##Relative); \
   this->addOperationCaller(get##return_type_str##Absolute); \
@@ -51,6 +55,8 @@
 #define DECLARE_ROSPARAM_OPERATION_CALLER(return_type_str, return_type) \
   RTT::OperationCaller<bool(const std::string &, return_type &)>        get##return_type_str; \
   RTT::OperationCaller<void(const std::string &, const return_type &)>  set##return_type_str; \
+  RTT::OperationCaller<return_type(const std::string &)> getParam##return_type_str; \
+  RTT::OperationCaller<void(const std::string &, const return_type &)>  setParam##return_type_str; \
   RTT::OperationCaller<bool(const std::string &, return_type &)>        get##return_type_str##Relative; \
   RTT::OperationCaller<void(const std::string &, const return_type &)>  set##return_type_str##Relative; \
   RTT::OperationCaller<bool(const std::string &, return_type &)>        get##return_type_str##Absolute; \


### PR DESCRIPTION

# Description

This PR adds support to access the value ROS parameter directly from one operation.

## Content

The next operations are added to the `rosparam` service:
* `getParam_type_(name)`: Gets the value of the ROS parameter named `name`. The namespace resolution is included in the `name` format. The value is returned instead of being assigned to an output parameter.
* `setParam_type_(name, value)`: Sets the value of a ROS parameter `name` to `value`. There is not need of an intermediary property. The name resolution is included in the `name` format.
