### PR TITLE
rtt_roscomm: Shortcut ROS spinner callback queue for rtt subscribers

### DIFF
--- a/rtt_roscomm/CMakeLists.txt
+++ b/rtt_roscomm/CMakeLists.txt
@@ -17,6 +17,10 @@ orocos_library(rtt_rostopic
   src/rtt_rostopic.cpp)
 target_link_libraries(rtt_rostopic ${catkin_LIBRARIES})
 
+orocos_library(passthrough_callback_queue
+  src/passthrough_callback_queue.cpp)
+target_link_libraries(passthrough_callback_queue ${catkin_LIBRARIES})
+
 orocos_service(rtt_rostopic_service
   src/rtt_rostopic_service.cpp
   src/rtt_rostopic_ros_publish_activity.cpp)

--- a/rtt_roscomm/include/rtt_roscomm/passthrough_callback_queue.hpp
+++ b/rtt_roscomm/include/rtt_roscomm/passthrough_callback_queue.hpp
@@ -1,4 +1,3 @@
-
 #ifndef RTT_ROSCOMM__PASSTHROUGH_CALLBACK_QUEUE_HPP_
 #define RTT_ROSCOMM__PASSTHROUGH_CALLBACK_QUEUE_HPP_
 
@@ -8,224 +7,39 @@
 #include <ros/callback_queue.h>
 
 namespace rtt_roscomm {
-  class PassthroughCallbackQueue: public ros::CallbackQueueInterface
-  {
-    public:
-      PassthroughCallbackQueue();
+class PassthroughCallbackQueue: public ros::CallbackQueueInterface
+{
+  public:
+    /** 
+     * Implementation of ros::CallbackQueueInterface::addCallback()
+     * 
+     * This method is executing the callback received instead of adding
+     * it to a queue. In this way, the queue is bypassed and immediately
+     * executed.
+     * 
+     * @param callback callback to execute, instead of queueing
+     * @param owner_id Owner of the callback, in other implementations it might
+     *                 be used to remove the callback. In this implementation
+     *                 it has no effect.
+     * 
+     * @return void
+     */
+    virtual void addCallback(
+        const ros::CallbackInterfacePtr &callback,
+        uint64_t owner_id=0);
 
-      /** 
-       * Implementation of ros::CallbackQueueInterface::addCallback()
-       * 
-       * @param callback aaa
-       * @param owner_id aaa
-       * 
-       * @return void
-       */
-      virtual void addCallback(
-          const ros::CallbackInterfacePtr &callback,
-          uint64_t owner_id=0);
+    /** 
+     * Implementation of ros::CallbackQueueInterface::removeByID()
+     * 
+     * No-op
+     * 
+     * @param owner_id Not used.
+     * 
+     * @return void
+     */
+    virtual void removeByID(uint64_t owner_id) {}
 
-      /** 
-       * Implementation of ros::CallbackQueueInterface::removeByID()
-       * 
-       * @param owner_id aaa
-       * 
-       * @return void
-       */
-      virtual void removeByID(uint64_t owner_id);
-
-    private:
-
-      /**
-       * Port where to write the message
-       */
-      // base::PortInterface* output_port_ptr_;
-
-  }; // class PassthroughCallbackQueue
-
-  /**
-   * Helpers to generate subscribers with a custom ros::CallbackQueueInterface
-   */
-
-      // template<class M, class T>
-    // ros::Subscriber subscribe(const std::string& topic, uint32_t queue_size, 
-    //                     void(T::*fp)(const boost::shared_ptr<M const>&) const, T* obj,
-    //                     ros::CallbackQueueInterface* cq, ros::NodeHandle& nh,
-    //                     const TransportHints& transport_hints = ros::TransportHints())
-    // {
-    //   ros::SubscribeOptions ops;
-    //   ops.template init<M>(topic, queue_size, boost::bind(fp, obj, _1));
-    //   ops.transport_hints = transport_hints;
-    //   ops.callback_queue = cq;
-    //   return nh.subscribe(ops);
-    // }
-
-  template<class M, class T>
-  ros::Subscriber subscribe(
-      ros::NodeHandle& nh, ros::CallbackQueueInterface* cq,
-      const std::string& topic, uint32_t queue_size, void(T::*fp)(M), T* obj, 
-      const ros::TransportHints& transport_hints = ros::TransportHints())
-  {
-    ros::SubscribeOptions ops;
-    ops.template initByFullCallbackType<M>(topic, queue_size, boost::bind(fp, obj, _1));
-    ops.transport_hints = transport_hints;
-    ops.callback_queue = cq;
-    return nh.subscribe(ops);
-  }
-
-  /// and the const version
-  template<class M, class T>
-  ros::Subscriber subscribe(
-      ros::NodeHandle& nh, ros::CallbackQueueInterface* cq,
-      const std::string& topic, uint32_t queue_size, void(T::*fp)(M) const, T* obj, 
-      const ros::TransportHints& transport_hints = ros::TransportHints())
-  {
-    ros::SubscribeOptions ops;
-    ops.template initByFullCallbackType<M>(topic, queue_size, boost::bind(fp, obj, _1));
-    ops.transport_hints = transport_hints;
-    ops.callback_queue = cq;
-    return nh.subscribe(ops);
-  }
-  template<class M, class T>
-  ros::Subscriber subscribe(
-      ros::NodeHandle& nh, ros::CallbackQueueInterface* cq,
-      const std::string& topic, uint32_t queue_size, 
-      void(T::*fp)(const boost::shared_ptr<M const>&), T* obj, 
-      const ros::TransportHints& transport_hints = ros::TransportHints())
-  {
-    ros::SubscribeOptions ops;
-    ops.template init<M>(topic, queue_size, boost::bind(fp, obj, _1));
-    ops.transport_hints = transport_hints;
-    ops.callback_queue = cq;
-    return nh.subscribe(ops);
-  }
-  template<class M, class T>
-  ros::Subscriber subscribe(
-      ros::NodeHandle& nh, ros::CallbackQueueInterface* cq,
-      const std::string& topic, uint32_t queue_size, 
-      void(T::*fp)(const boost::shared_ptr<M const>&) const, T* obj, 
-      const ros::TransportHints& transport_hints = ros::TransportHints())
-  {
-    ros::SubscribeOptions ops;
-    ops.template init<M>(topic, queue_size, boost::bind(fp, obj, _1));
-    ops.transport_hints = transport_hints;
-    ops.callback_queue = cq;
-    return nh.subscribe(ops);
-  }
-  template<class M, class T>
-  ros::Subscriber subscribe(
-      ros::NodeHandle& nh, ros::CallbackQueueInterface* cq,
-      const std::string& topic, uint32_t queue_size, void(T::*fp)(M), 
-      const boost::shared_ptr<T>& obj,
-      const ros::TransportHints& transport_hints = ros::TransportHints())
-  {
-    ros::SubscribeOptions ops;
-    ops.template initByFullCallbackType<M>(topic, queue_size, boost::bind(fp, obj.get(), _1));
-    ops.tracked_object = obj;
-    ops.transport_hints = transport_hints;
-    ops.callback_queue = cq;
-    return nh.subscribe(ops);
-  }
-
-  template<class M, class T>
-  ros::Subscriber subscribe(
-      ros::NodeHandle& nh, ros::CallbackQueueInterface* cq,
-      const std::string& topic, uint32_t queue_size, void(T::*fp)(M) const, 
-      const boost::shared_ptr<T>& obj,
-      const ros::TransportHints& transport_hints = ros::TransportHints())
-  {
-    ros::SubscribeOptions ops;
-    ops.template initByFullCallbackType<M>(topic, queue_size, boost::bind(fp, obj.get(), _1));
-    ops.tracked_object = obj;
-    ops.transport_hints = transport_hints;
-    ops.callback_queue = cq;
-    return nh.subscribe(ops);
-  }
-  template<class M, class T>
-  ros::Subscriber subscribe(
-      ros::NodeHandle& nh, ros::CallbackQueueInterface* cq,
-      const std::string& topic, uint32_t queue_size, 
-      void(T::*fp)(const boost::shared_ptr<M const>&), 
-      const boost::shared_ptr<T>& obj,
-      const ros::TransportHints& transport_hints = ros::TransportHints())
-  {
-    ros::SubscribeOptions ops;
-    ops.template init<M>(topic, queue_size, boost::bind(fp, obj.get(), _1));
-    ops.tracked_object = obj;
-    ops.transport_hints = transport_hints;
-    ops.callback_queue = cq;
-    return nh.subscribe(ops);
-  }
-  template<class M, class T>
-  ros::Subscriber subscribe(
-      ros::NodeHandle& nh, ros::CallbackQueueInterface* cq,
-      const std::string& topic, uint32_t queue_size, 
-      void(T::*fp)(const boost::shared_ptr<M const>&) const, 
-      const boost::shared_ptr<T>& obj,
-      const ros::TransportHints& transport_hints = ros::TransportHints())
-  {
-    ros::SubscribeOptions ops;
-    ops.template init<M>(topic, queue_size, boost::bind(fp, obj.get(), _1));
-    ops.tracked_object = obj;
-    ops.transport_hints = transport_hints;
-    ops.callback_queue = cq;
-    return nh.subscribe(ops);
-  }
-  template<class M>
-  ros::Subscriber subscribe(
-      ros::NodeHandle& nh, ros::CallbackQueueInterface* cq,
-      const std::string& topic, uint32_t queue_size, void(*fp)(M),
-      const ros::TransportHints& transport_hints = ros::TransportHints())
-  {
-    ros::SubscribeOptions ops;
-    ops.template initByFullCallbackType<M>(topic, queue_size, fp);
-    ops.transport_hints = transport_hints;
-    ops.callback_queue = cq;
-    return nh.subscribe(ops);
-  }
-  template<class M>
-  ros::Subscriber subscribe(
-      ros::NodeHandle& nh, ros::CallbackQueueInterface* cq,
-      const std::string& topic, uint32_t queue_size,
-      void(*fp)(const boost::shared_ptr<M const>&),
-      const ros::TransportHints& transport_hints = ros::TransportHints())
-  {
-    ros::SubscribeOptions ops;
-    ops.template init<M>(topic, queue_size, fp);
-    ops.transport_hints = transport_hints;
-    ops.callback_queue = cq;
-    return nh.subscribe(ops);
-  }
-  template<class M>
-  ros::Subscriber subscribe(
-      ros::NodeHandle& nh, ros::CallbackQueueInterface* cq,
-      const std::string& topic, uint32_t queue_size,
-      const boost::function<void (const boost::shared_ptr<M const>&)>& callback,
-      const ros::VoidConstPtr& tracked_object = ros::VoidConstPtr(),
-      const ros::TransportHints& transport_hints = ros::TransportHints())
-  {
-    ros::SubscribeOptions ops;
-    ops.template init<M>(topic, queue_size, callback);
-    ops.tracked_object = tracked_object;
-    ops.transport_hints = transport_hints;
-    ops.callback_queue = cq;
-    return nh.subscribe(ops);
-  }
-  template<class M, class C>
-  ros::Subscriber subscribe(
-      ros::NodeHandle& nh, ros::CallbackQueueInterface* cq,
-      const std::string& topic, uint32_t queue_size,
-      const boost::function<void (C)>& callback,
-      const ros::VoidConstPtr& tracked_object = ros::VoidConstPtr(),
-      const ros::TransportHints& transport_hints = ros::TransportHints())
-  {
-    ros::SubscribeOptions ops;
-    ops.template initByFullCallbackType<C>(topic, queue_size, callback);
-    ops.tracked_object = tracked_object;
-    ops.transport_hints = transport_hints;
-    ops.callback_queue = cq;
-    return nh.subscribe(ops);
-  }
+}; // class PassthroughCallbackQueue
 
 } // namespace rtt_roscomm
 

--- a/rtt_roscomm/include/rtt_roscomm/passthrough_callback_queue.hpp
+++ b/rtt_roscomm/include/rtt_roscomm/passthrough_callback_queue.hpp
@@ -43,15 +43,11 @@ class PassthroughCallbackQueue: public ros::CallbackQueueInterface
      * Implementation of ros::CallbackQueueInterface::addCallback()
      * 
      * This method is executing the callback received instead of adding
-     * it to a queue. In this way, the queue is bypassed and immediately
-     * executed.
+     * it to a queue. In this way, the queue is bypassed and the callback is
+     * immediately executed.
      * 
      * @param callback callback to execute, instead of queueing
-     * @param owner_id Owner of the callback, in other implementations it might
-     *                 be used to remove the callback. In this implementation
-     *                 it has no effect.
-     * 
-     * @return void
+     * @param owner_id Not used
      */
     virtual void addCallback(
         const ros::CallbackInterfacePtr &callback,
@@ -63,8 +59,6 @@ class PassthroughCallbackQueue: public ros::CallbackQueueInterface
      * No-op
      * 
      * @param owner_id Not used.
-     * 
-     * @return void
      */
     virtual void removeByID(uint64_t owner_id) {}
 

--- a/rtt_roscomm/include/rtt_roscomm/passthrough_callback_queue.hpp
+++ b/rtt_roscomm/include/rtt_roscomm/passthrough_callback_queue.hpp
@@ -1,0 +1,232 @@
+
+#ifndef RTT_ROSCOMM__PASSTHROUGH_CALLBACK_QUEUE_HPP_
+#define RTT_ROSCOMM__PASSTHROUGH_CALLBACK_QUEUE_HPP_
+
+#include <ros/ros.h>
+#include <ros/callback_queue_interface.h>
+#include <ros/subscription_queue.h>
+#include <ros/callback_queue.h>
+
+namespace rtt_roscomm {
+  class PassthroughCallbackQueue: public ros::CallbackQueueInterface
+  {
+    public:
+      PassthroughCallbackQueue();
+
+      /** 
+       * Implementation of ros::CallbackQueueInterface::addCallback()
+       * 
+       * @param callback aaa
+       * @param owner_id aaa
+       * 
+       * @return void
+       */
+      virtual void addCallback(
+          const ros::CallbackInterfacePtr &callback,
+          uint64_t owner_id=0);
+
+      /** 
+       * Implementation of ros::CallbackQueueInterface::removeByID()
+       * 
+       * @param owner_id aaa
+       * 
+       * @return void
+       */
+      virtual void removeByID(uint64_t owner_id);
+
+    private:
+
+      /**
+       * Port where to write the message
+       */
+      // base::PortInterface* output_port_ptr_;
+
+  }; // class PassthroughCallbackQueue
+
+  /**
+   * Helpers to generate subscribers with a custom ros::CallbackQueueInterface
+   */
+
+      // template<class M, class T>
+    // ros::Subscriber subscribe(const std::string& topic, uint32_t queue_size, 
+    //                     void(T::*fp)(const boost::shared_ptr<M const>&) const, T* obj,
+    //                     ros::CallbackQueueInterface* cq, ros::NodeHandle& nh,
+    //                     const TransportHints& transport_hints = ros::TransportHints())
+    // {
+    //   ros::SubscribeOptions ops;
+    //   ops.template init<M>(topic, queue_size, boost::bind(fp, obj, _1));
+    //   ops.transport_hints = transport_hints;
+    //   ops.callback_queue = cq;
+    //   return nh.subscribe(ops);
+    // }
+
+  template<class M, class T>
+  ros::Subscriber subscribe(
+      ros::NodeHandle& nh, ros::CallbackQueueInterface* cq,
+      const std::string& topic, uint32_t queue_size, void(T::*fp)(M), T* obj, 
+      const ros::TransportHints& transport_hints = ros::TransportHints())
+  {
+    ros::SubscribeOptions ops;
+    ops.template initByFullCallbackType<M>(topic, queue_size, boost::bind(fp, obj, _1));
+    ops.transport_hints = transport_hints;
+    ops.callback_queue = cq;
+    return nh.subscribe(ops);
+  }
+
+  /// and the const version
+  template<class M, class T>
+  ros::Subscriber subscribe(
+      ros::NodeHandle& nh, ros::CallbackQueueInterface* cq,
+      const std::string& topic, uint32_t queue_size, void(T::*fp)(M) const, T* obj, 
+      const ros::TransportHints& transport_hints = ros::TransportHints())
+  {
+    ros::SubscribeOptions ops;
+    ops.template initByFullCallbackType<M>(topic, queue_size, boost::bind(fp, obj, _1));
+    ops.transport_hints = transport_hints;
+    ops.callback_queue = cq;
+    return nh.subscribe(ops);
+  }
+  template<class M, class T>
+  ros::Subscriber subscribe(
+      ros::NodeHandle& nh, ros::CallbackQueueInterface* cq,
+      const std::string& topic, uint32_t queue_size, 
+      void(T::*fp)(const boost::shared_ptr<M const>&), T* obj, 
+      const ros::TransportHints& transport_hints = ros::TransportHints())
+  {
+    ros::SubscribeOptions ops;
+    ops.template init<M>(topic, queue_size, boost::bind(fp, obj, _1));
+    ops.transport_hints = transport_hints;
+    ops.callback_queue = cq;
+    return nh.subscribe(ops);
+  }
+  template<class M, class T>
+  ros::Subscriber subscribe(
+      ros::NodeHandle& nh, ros::CallbackQueueInterface* cq,
+      const std::string& topic, uint32_t queue_size, 
+      void(T::*fp)(const boost::shared_ptr<M const>&) const, T* obj, 
+      const ros::TransportHints& transport_hints = ros::TransportHints())
+  {
+    ros::SubscribeOptions ops;
+    ops.template init<M>(topic, queue_size, boost::bind(fp, obj, _1));
+    ops.transport_hints = transport_hints;
+    ops.callback_queue = cq;
+    return nh.subscribe(ops);
+  }
+  template<class M, class T>
+  ros::Subscriber subscribe(
+      ros::NodeHandle& nh, ros::CallbackQueueInterface* cq,
+      const std::string& topic, uint32_t queue_size, void(T::*fp)(M), 
+      const boost::shared_ptr<T>& obj,
+      const ros::TransportHints& transport_hints = ros::TransportHints())
+  {
+    ros::SubscribeOptions ops;
+    ops.template initByFullCallbackType<M>(topic, queue_size, boost::bind(fp, obj.get(), _1));
+    ops.tracked_object = obj;
+    ops.transport_hints = transport_hints;
+    ops.callback_queue = cq;
+    return nh.subscribe(ops);
+  }
+
+  template<class M, class T>
+  ros::Subscriber subscribe(
+      ros::NodeHandle& nh, ros::CallbackQueueInterface* cq,
+      const std::string& topic, uint32_t queue_size, void(T::*fp)(M) const, 
+      const boost::shared_ptr<T>& obj,
+      const ros::TransportHints& transport_hints = ros::TransportHints())
+  {
+    ros::SubscribeOptions ops;
+    ops.template initByFullCallbackType<M>(topic, queue_size, boost::bind(fp, obj.get(), _1));
+    ops.tracked_object = obj;
+    ops.transport_hints = transport_hints;
+    ops.callback_queue = cq;
+    return nh.subscribe(ops);
+  }
+  template<class M, class T>
+  ros::Subscriber subscribe(
+      ros::NodeHandle& nh, ros::CallbackQueueInterface* cq,
+      const std::string& topic, uint32_t queue_size, 
+      void(T::*fp)(const boost::shared_ptr<M const>&), 
+      const boost::shared_ptr<T>& obj,
+      const ros::TransportHints& transport_hints = ros::TransportHints())
+  {
+    ros::SubscribeOptions ops;
+    ops.template init<M>(topic, queue_size, boost::bind(fp, obj.get(), _1));
+    ops.tracked_object = obj;
+    ops.transport_hints = transport_hints;
+    ops.callback_queue = cq;
+    return nh.subscribe(ops);
+  }
+  template<class M, class T>
+  ros::Subscriber subscribe(
+      ros::NodeHandle& nh, ros::CallbackQueueInterface* cq,
+      const std::string& topic, uint32_t queue_size, 
+      void(T::*fp)(const boost::shared_ptr<M const>&) const, 
+      const boost::shared_ptr<T>& obj,
+      const ros::TransportHints& transport_hints = ros::TransportHints())
+  {
+    ros::SubscribeOptions ops;
+    ops.template init<M>(topic, queue_size, boost::bind(fp, obj.get(), _1));
+    ops.tracked_object = obj;
+    ops.transport_hints = transport_hints;
+    ops.callback_queue = cq;
+    return nh.subscribe(ops);
+  }
+  template<class M>
+  ros::Subscriber subscribe(
+      ros::NodeHandle& nh, ros::CallbackQueueInterface* cq,
+      const std::string& topic, uint32_t queue_size, void(*fp)(M),
+      const ros::TransportHints& transport_hints = ros::TransportHints())
+  {
+    ros::SubscribeOptions ops;
+    ops.template initByFullCallbackType<M>(topic, queue_size, fp);
+    ops.transport_hints = transport_hints;
+    ops.callback_queue = cq;
+    return nh.subscribe(ops);
+  }
+  template<class M>
+  ros::Subscriber subscribe(
+      ros::NodeHandle& nh, ros::CallbackQueueInterface* cq,
+      const std::string& topic, uint32_t queue_size,
+      void(*fp)(const boost::shared_ptr<M const>&),
+      const ros::TransportHints& transport_hints = ros::TransportHints())
+  {
+    ros::SubscribeOptions ops;
+    ops.template init<M>(topic, queue_size, fp);
+    ops.transport_hints = transport_hints;
+    ops.callback_queue = cq;
+    return nh.subscribe(ops);
+  }
+  template<class M>
+  ros::Subscriber subscribe(
+      ros::NodeHandle& nh, ros::CallbackQueueInterface* cq,
+      const std::string& topic, uint32_t queue_size,
+      const boost::function<void (const boost::shared_ptr<M const>&)>& callback,
+      const ros::VoidConstPtr& tracked_object = ros::VoidConstPtr(),
+      const ros::TransportHints& transport_hints = ros::TransportHints())
+  {
+    ros::SubscribeOptions ops;
+    ops.template init<M>(topic, queue_size, callback);
+    ops.tracked_object = tracked_object;
+    ops.transport_hints = transport_hints;
+    ops.callback_queue = cq;
+    return nh.subscribe(ops);
+  }
+  template<class M, class C>
+  ros::Subscriber subscribe(
+      ros::NodeHandle& nh, ros::CallbackQueueInterface* cq,
+      const std::string& topic, uint32_t queue_size,
+      const boost::function<void (C)>& callback,
+      const ros::VoidConstPtr& tracked_object = ros::VoidConstPtr(),
+      const ros::TransportHints& transport_hints = ros::TransportHints())
+  {
+    ros::SubscribeOptions ops;
+    ops.template initByFullCallbackType<C>(topic, queue_size, callback);
+    ops.tracked_object = tracked_object;
+    ops.transport_hints = transport_hints;
+    ops.callback_queue = cq;
+    return nh.subscribe(ops);
+  }
+
+} // namespace rtt_roscomm
+
+#endif // RTT_ROSCOMM__PASSTHROUGH_CALLBACK_QUEUE_HPP_

--- a/rtt_roscomm/include/rtt_roscomm/passthrough_callback_queue.hpp
+++ b/rtt_roscomm/include/rtt_roscomm/passthrough_callback_queue.hpp
@@ -1,3 +1,32 @@
+/*
+ * (C) 2020, Intermodalics BVBA
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #ifndef RTT_ROSCOMM__PASSTHROUGH_CALLBACK_QUEUE_HPP_
 #define RTT_ROSCOMM__PASSTHROUGH_CALLBACK_QUEUE_HPP_
 

--- a/rtt_roscomm/include/rtt_roscomm/rtt_rostopic_ros_msg_transporter.hpp
+++ b/rtt_roscomm/include/rtt_roscomm/rtt_rostopic_ros_msg_transporter.hpp
@@ -260,7 +260,7 @@ namespace rtt_roscomm {
       ros::SubscribeOptions ops;
       ops.template initByFullCallbackType<const RosType&>(
           topicname,
-          policy.size > 0 ? policy.size : 1,  // minimum queue_size 1
+          1u,  // Always 1, since data can be buffered in RTT buffer
           boost::bind(&RosSubChannelElement::newData, this, _1));
       ops.callback_queue = &passthrough_callback_queue;
 

--- a/rtt_roscomm/include/rtt_roscomm/rtt_rostopic_ros_msg_transporter.hpp
+++ b/rtt_roscomm/include/rtt_roscomm/rtt_rostopic_ros_msg_transporter.hpp
@@ -148,8 +148,6 @@ namespace rtt_roscomm {
     }
 
     ~RosPubChannelElement() {
-      RTT::Logger::In in(topicname);
-//      RTT::log(RTT::Debug) << "Destroying RosPubChannelElement" << RTT::endlog();
       act->removePublisher( this );
     }
 
@@ -241,8 +239,8 @@ namespace rtt_roscomm {
     std::string topicname;
     ros::NodeHandle ros_node;
     ros::NodeHandle ros_node_private;
+    PassthroughCallbackQueue passthrough_callback_queue;
     ros::Subscriber ros_sub;
-    PassthroughCallbackQueue prassthrough_callback_queue;
     
   public:
     /** 
@@ -258,7 +256,14 @@ namespace rtt_roscomm {
       ros_node(),
       ros_node_private("~")
     {
-      topicname=policy.name_id;
+      topicname = policy.name_id;
+      ros::SubscribeOptions ops;
+      ops.template initByFullCallbackType<const RosType&>(
+          topicname,
+          policy.size > 0 ? policy.size : 1,  // minimum queue_size 1
+          boost::bind(&RosSubChannelElement::newData, this, _1));
+      ops.callback_queue = &passthrough_callback_queue;
+
       RTT::Logger::In in(topicname);
       if (port->getInterface() && port->getInterface()->getOwner()) {
         RTT::log(RTT::Debug)<<"Creating ROS subscriber for port "<<port->getInterface()->getOwner()->getName()<<"."<<port->getName()<<" on topic "<<policy.name_id<<RTT::endlog();
@@ -266,15 +271,15 @@ namespace rtt_roscomm {
         RTT::log(RTT::Debug)<<"Creating ROS subscriber for port "<<port->getName()<<" on topic "<<policy.name_id<<RTT::endlog();
       }
       if(topicname.length() > 1 && topicname.at(0) == '~') {
-        ros_sub = subscribe(ros_node_private, &prassthrough_callback_queue, policy.name_id.substr(1), policy.size > 0 ? policy.size : 1, &RosSubChannelElement::newData, this); // minimum queue_size 1
+        ops.topic = ops.topic.substr(1);
+        ros_sub = ros_node_private.subscribe(ops);
       } else {
-        ros_sub = subscribe(ros_node, &prassthrough_callback_queue, policy.name_id, policy.size > 0 ? policy.size : 1, &RosSubChannelElement::newData, this); // minimum queue_size 1
+        ros_sub = ros_node.subscribe(ops);
       }
     }
 
     ~RosSubChannelElement() {
-      RTT::Logger::In in(topicname);
-//      RTT::log(RTT::Debug)<<"Destroying RosSubChannelElement"<<RTT::endlog();
+      ros_sub.shutdown();
     }
 
     virtual bool inputReady() {

--- a/rtt_roscomm/include/rtt_roscomm/rtt_rostopic_ros_msg_transporter.hpp
+++ b/rtt_roscomm/include/rtt_roscomm/rtt_rostopic_ros_msg_transporter.hpp
@@ -56,6 +56,7 @@
 #include <rtt/internal/ConnFactory.hpp>
 #include <ros/ros.h>
 
+#include <rtt_roscomm/passthrough_callback_queue.hpp>
 #include <rtt_roscomm/rtt_rostopic_ros_publish_activity.hpp>
 
 #ifndef RTT_VERSION_GTE
@@ -241,6 +242,7 @@ namespace rtt_roscomm {
     ros::NodeHandle ros_node;
     ros::NodeHandle ros_node_private;
     ros::Subscriber ros_sub;
+    PassthroughCallbackQueue prassthrough_callback_queue;
     
   public:
     /** 
@@ -264,9 +266,9 @@ namespace rtt_roscomm {
         RTT::log(RTT::Debug)<<"Creating ROS subscriber for port "<<port->getName()<<" on topic "<<policy.name_id<<RTT::endlog();
       }
       if(topicname.length() > 1 && topicname.at(0) == '~') {
-        ros_sub = ros_node_private.subscribe(policy.name_id.substr(1), policy.size > 0 ? policy.size : 1, &RosSubChannelElement::newData, this); // minimum queue_size 1
+        ros_sub = subscribe(ros_node_private, &prassthrough_callback_queue, policy.name_id.substr(1), policy.size > 0 ? policy.size : 1, &RosSubChannelElement::newData, this); // minimum queue_size 1
       } else {
-        ros_sub = ros_node.subscribe(policy.name_id, policy.size > 0 ? policy.size : 1, &RosSubChannelElement::newData, this); // minimum queue_size 1
+        ros_sub = subscribe(ros_node, &prassthrough_callback_queue, policy.name_id, policy.size > 0 ? policy.size : 1, &RosSubChannelElement::newData, this); // minimum queue_size 1
       }
     }
 
@@ -350,6 +352,6 @@ namespace rtt_roscomm {
 
       return channel;
     }
-  };
-} 
+  }; // class RosMsgTransporter
+} // namespace rtt_roscomm
 #endif

--- a/rtt_roscomm/src/passthrough_callback_queue.cpp
+++ b/rtt_roscomm/src/passthrough_callback_queue.cpp
@@ -1,24 +1,15 @@
-
 #include "rtt_roscomm/passthrough_callback_queue.hpp"
 
 namespace rtt_roscomm {
-
-PassthroughCallbackQueue::PassthroughCallbackQueue()
-        {}
 
 void PassthroughCallbackQueue::addCallback(
     const ros::CallbackInterfacePtr &callback,
     uint64_t owner_id)
 {
-  // Call CallbackInterface::CallResult SubscriptionQueue::call()
-  if (ros::CallbackInterface::TryAgain == callback->call()) {
+  ros::CallbackInterface::CallResult result = callback->call();
+  if (ros::CallbackInterface::TryAgain == result) {
     ros::getGlobalCallbackQueue()->addCallback(callback, owner_id);
   }
 }
 
-void PassthroughCallbackQueue::removeByID(uint64_t owner_id)
-{
-}
-
 } // namespace rtt_roscomm
-

--- a/rtt_roscomm/src/passthrough_callback_queue.cpp
+++ b/rtt_roscomm/src/passthrough_callback_queue.cpp
@@ -1,3 +1,32 @@
+/*
+ * (C) 2020, Intermodalics BVBA
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #include "rtt_roscomm/passthrough_callback_queue.hpp"
 
 namespace rtt_roscomm {

--- a/rtt_roscomm/src/passthrough_callback_queue.cpp
+++ b/rtt_roscomm/src/passthrough_callback_queue.cpp
@@ -1,0 +1,24 @@
+
+#include "rtt_roscomm/passthrough_callback_queue.hpp"
+
+namespace rtt_roscomm {
+
+PassthroughCallbackQueue::PassthroughCallbackQueue()
+        {}
+
+void PassthroughCallbackQueue::addCallback(
+    const ros::CallbackInterfacePtr &callback,
+    uint64_t owner_id)
+{
+  // Call CallbackInterface::CallResult SubscriptionQueue::call()
+  if (ros::CallbackInterface::TryAgain == callback->call()) {
+    ros::getGlobalCallbackQueue()->addCallback(callback, owner_id);
+  }
+}
+
+void PassthroughCallbackQueue::removeByID(uint64_t owner_id)
+{
+}
+
+} // namespace rtt_roscomm
+


### PR DESCRIPTION

# Optimized ROS subscription pipeline using a custom `CallbackQueueInterface` implementation

Optimized ROS subscription pipeline, avoiding unnecessary copies by directly pushing the data to Orocos and bypassing unnecessary ROS threads.

## Goal

Do not depend on ROS spinner threads for subscriptions. Minimize latency of port reads and decouple multiple components with ROS subscriptions connected to ports. At the moment they all share the same pool of ROS spinner threads.

## Approach

The patch introduces a new "queue" without a queue to bypass the global `ros::CallbackQueue` of ROS for the subscripers of Orocos messages. Instead, the network thread will immediately execute the callback, and will pass it to the global `ros::CallbackQueue` only in case that it fails to execute with `ros::CallbackInterface::TryAgain` status.

## Implementation

* A new implementation of `ros::CallbackQueueInterface` is provided that doesn't hold a queue but directly calls the `call()` method of the `ros::CallbackInterface` received.
* Helper functions are provided to generate a subscriber with a custom implementation of `CallbackQueueInterface`.
* This method is chosen for the subscribers of the message transporter.

## References

#### Callbacks and spinning
Explanation about Callbacks and Spinning:
http://wiki.ros.org/roscpp/Overview/Callbacks%20and%20Spinning

Check specially the section 4. Advanced: Using Different Callback Queues.
Our use-case is not in 4.1. Shortcutting the callback queue by not having a queue.

#### Function `Subscriber::subscribe()`

[Reference](https://github.com/ros/ros_comm/blob/ae2501fec33de9a19abe87199bbf60171c05dd34/clients/roscpp/include/ros/node_handle.h#L402)

All the overloaded `Subscriber::subscribe()` creates a `SubscribeOptions ops` and calls `subscribe(ops)`. The way to use a custom callback queue is to replace then entry in `SubscribeOptions` options as in `ops.callback_queue` different` from `0` (`0` is default `callback_queue`, the ROS global queue callback).

#### Function `CallbackQueue::callOneCB()`

[Reference](https://github.com/ros/ros_comm/blob/ae2501fec33de9a19abe87199bbf60171c05dd34/clients/roscpp/src/libros/callback_queue.cpp#L346)

The function `CallbackQueue::callOneCB()` executes a callback and then it removes it. The execution of the callback,
inherited from `CallbackInterface` is a simple `cb->call()`. In this case, the `CallbackInterface` is itself a `SubscriptionQueue` which can be executed through that `call()`.
The function also deals with `ros::CallbackInterface::TryAgain` result, which would be the case if in a multi-threaded situation the callback is being taken by another thread. We don't expect to get into this situation ever, but in case it happens, we can forward the callback to the global callback queue and let the ROS spinner deal with it, as in the original behavior.

#### Function `Subscription::handleMessage()`

[Reference](https://github.com/ros/ros_comm/blob/ae2501fec33de9a19abe87199bbf60171c05dd34/clients/roscpp/src/libros/subscription.cpp#L657)

The function `Subscription::handleMessage()` is the function that calls the `addCallback()` to push the callback to the global queue for a subscription.

#### Function `SubscriptionQueue::call()`

[Reference](https://github.com/ros/ros_comm/blob/121bac963e90b9a0bb33cc368ef4373a2f65ddff/clients/roscpp/src/libros/subscription_queue.cpp#L102)

The `SubscriptionQueue` is itself a `CallbackInterface` so it can be `call()`ed which executes normally all the needed delivery of the message.
