### PR TITLE
rtt_rosparam_tests: add unit tests for the new DataSource feature

### DIFF
--- a/rtt_rosparam/src/rtt_rosparam_service.cpp
+++ b/rtt_rosparam/src/rtt_rosparam_service.cpp
@@ -30,7 +30,11 @@
   this->addOperation("get"#return_type_str"ComponentRelative", &ROSParamService::get##func< return_type , COMPONENT_RELATIVE >, this).doc("Get a " #return_type " from rosparam using the following resolution policy : `component_name/param`"); \
   this->addOperation("set"#return_type_str"ComponentRelative", &ROSParamService::set##func< return_type , COMPONENT_RELATIVE >, this).doc("Set a " #return_type " in rosparam using the following resolution policy : `component_name/param`"); \
   this->addOperation("get"#return_type_str"ComponentAbsolute", &ROSParamService::get##func< return_type , COMPONENT_ABSOLUTE >, this).doc("Get a " #return_type " from rosparam using the following resolution policy : `/component_name/param`"); \
-  this->addOperation("set"#return_type_str"ComponentAbsolute", &ROSParamService::set##func< return_type , COMPONENT_ABSOLUTE >, this).doc("Set a " #return_type " in rosparam using the following resolution policy : `/component_name/param`"); \
+  this->addOperation("set"#return_type_str"ComponentAbsolute", &ROSParamService::set##func< return_type , COMPONENT_ABSOLUTE >, this).doc("Set a " #return_type " in rosparam using the following resolution policy : `/component_name/param`");
+#endif
+
+#ifndef ADD_ROSPARAM_PROPERTY_OPERATION
+#define ADD_ROSPARAM_PROPERTY_OPERATION(return_type_str, return_type, func) \
   this->addOperation("addRosParamProperty"#return_type_str, &ROSParamService::addRosParamProperty<return_type, RELATIVE>, this).doc("Adds a Property to the owner component that is linked to a ROS property of the same name").arg("name", "name of the ROS parameter, the property generated will use the same name"); \
   this->addOperation("addRosParamProperty"#return_type_str"Relative", &ROSParamService::addRosParamProperty<return_type, RELATIVE>, this).doc("Adds a Property to the owner component that is linked to a ROS property of the same name").arg("name", "name of the ROS parameter, the property generated will use the same name"); \
   this->addOperation("addRosParamProperty"#return_type_str"Absolute", &ROSParamService::addRosParamProperty<return_type, ABSOLUTE>, this).doc("Adds a Property to the owner component that is linked to a ROS property of the same name").arg("name", "name of the ROS parameter, the property generated will use the same name"); \
@@ -154,6 +158,11 @@ public:
     ADD_ROSPARAM_OPERATION(Float, float, ParamImpl)
     ADD_ROSPARAM_OPERATION(Int, int, ParamImpl)
     ADD_ROSPARAM_OPERATION(Bool, bool, ParamImpl)
+    ADD_ROSPARAM_PROPERTY_OPERATION(String, std::string, ParamImpl)
+    ADD_ROSPARAM_PROPERTY_OPERATION(Double, double, ParamImpl)
+    ADD_ROSPARAM_PROPERTY_OPERATION(Float, float, ParamImpl)
+    ADD_ROSPARAM_PROPERTY_OPERATION(Int, int, ParamImpl)
+    ADD_ROSPARAM_PROPERTY_OPERATION(Bool, bool, ParamImpl)
 
     // Vector parameters
     ADD_ROSPARAM_OPERATION(VectorOfString, std::vector<std::string>, ParamImpl)
@@ -161,6 +170,11 @@ public:
     ADD_ROSPARAM_OPERATION(VectorOfFloat, std::vector<float>, ParamImpl)
     ADD_ROSPARAM_OPERATION(VectorOfInt, std::vector<int>, ParamImpl)
     ADD_ROSPARAM_OPERATION(VectorOfBool, std::vector<bool>, ParamImpl)
+    ADD_ROSPARAM_PROPERTY_OPERATION(VectorOfString, std::vector<std::string>, ParamImpl)
+    ADD_ROSPARAM_PROPERTY_OPERATION(VectorOfDouble, std::vector<double>, ParamImpl)
+    ADD_ROSPARAM_PROPERTY_OPERATION(VectorOfFloat, std::vector<float>, ParamImpl)
+    ADD_ROSPARAM_PROPERTY_OPERATION(VectorOfInt, std::vector<int>, ParamImpl)
+    ADD_ROSPARAM_PROPERTY_OPERATION(VectorOfBool, std::vector<bool>, ParamImpl)
 
     ADD_ROSPARAM_OPERATION(EigenVectorXd, double, EigenVectorParamImpl)
     ADD_ROSPARAM_OPERATION(EigenVectorXf, float, EigenVectorParamImpl)

--- a/tests/rtt_rosparam_tests/test/param_tests.cpp
+++ b/tests/rtt_rosparam_tests/test/param_tests.cpp
@@ -642,55 +642,47 @@ TEST_F(ParamTest, SetValueOnParameterServer)
   compareValues(props, params, "set[Type]ComponentPrivate()", /* only_ros_types = */ true);
 }
 
-TEST_F(ParamTest, DirectAccessParameters)
-{
-  // initialize properties to some values
-  props.initialize();
-
-  // Read in ROS parameters directly (return value is the value)
-  rosparam->setParamBool("bool_parameter", props.bool_);
-  EXPECT_EQ(rosparam->getParamBool("bool_parameter"), props.bool_);
-  rosparam->setParamDouble("double_parameter", props.double_);
-  EXPECT_EQ(rosparam->getParamDouble("double_parameter"), props.double_);
-  rosparam->setParamFloat("float_parameter", props.float_);
-  EXPECT_EQ(rosparam->getParamFloat("float_parameter"), props.float_);
-  rosparam->setParamInt("int_parameter", props.int_);
-  EXPECT_EQ(rosparam->getParamInt("int_parameter"), props.int_);
-  rosparam->setParamString("string_parameter", props.string_);
-  EXPECT_EQ(rosparam->getParamString("string_parameter"), props.string_);
-}
-
 TEST_F(ParamTest, AddRosParamDataSources)
 {
   // initialize properties to some values
   props.initialize();
 
   // Read in parameters through data source
-  rosparam->setParamBool("bool_parameter", props.bool_);
+  ros::param::set("bool_parameter", props.bool_);
   EXPECT_EQ(rosparam->addRosParamPropertyBool("bool_parameter").value(), props.bool_);
-  rosparam->setParamDouble("double_parameter", props.double_);
+  ros::param::set("double_parameter", props.double_);
   EXPECT_EQ(rosparam->addRosParamPropertyDouble("double_parameter").value(), props.double_);
-  rosparam->setParamFloat("float_parameter", props.float_);
+  ros::param::set("float_parameter", props.float_);
   EXPECT_EQ(rosparam->addRosParamPropertyFloat("float_parameter").value(), props.float_);
-  rosparam->setParamInt("int_parameter", props.int_);
+  ros::param::set("int_parameter", props.int_);
   EXPECT_EQ(rosparam->addRosParamPropertyInt("int_parameter").value(), props.int_);
-  rosparam->setParamString("string_parameter", props.string_);
+  ros::param::set("string_parameter", props.string_);
   EXPECT_EQ(rosparam->addRosParamPropertyString("string_parameter").value(), props.string_);
 
   // change the props values to an alternative configuration
   props.initialize_alternative();
 
   // Write out paramters through data source
+  bool in_bool;
+  double in_double;
+  float in_float;
+  int in_int;
+  std::string in_string;
   dynamic_cast<RTT::Property<bool>*>(tc->getProperty("bool_parameter"))->set(props.bool_);
-  EXPECT_EQ(rosparam->getParamBool("bool_parameter"), props.bool_);
+  ros::param::get("bool_parameter", in_bool);
+  EXPECT_EQ(in_bool, props.bool_);
   dynamic_cast<RTT::Property<double>*>(tc->getProperty("double_parameter"))->set(props.double_);
-  EXPECT_EQ(rosparam->getParamDouble("double_parameter"), props.double_);
+  ros::param::get("double_parameter", in_double);
+  EXPECT_EQ(in_double, props.double_);
   dynamic_cast<RTT::Property<float>*>(tc->getProperty("float_parameter"))->set(props.float_);
-  EXPECT_EQ(rosparam->getParamFloat("float_parameter"), props.float_);
+  ros::param::get("float_parameter", in_float);
+  EXPECT_EQ(in_float, props.float_);
   dynamic_cast<RTT::Property<int>*>(tc->getProperty("int_parameter"))->set(props.int_);
-  EXPECT_EQ(rosparam->getParamInt("int_parameter"), props.int_);
+  ros::param::get("int_parameter", in_int);
+  EXPECT_EQ(in_int, props.int_);
   dynamic_cast<RTT::Property<std::string>*>(tc->getProperty("string_parameter"))->set(props.string_);
-  EXPECT_EQ(rosparam->getParamString("string_parameter"), props.string_);
+  ros::param::get("string_parameter", in_string);
+  EXPECT_EQ(in_string, props.string_);
 }
 
 TEST_F(ParamTest, GetValueFromParameterServer)

--- a/tests/rtt_rosparam_tests/test/param_tests.cpp
+++ b/tests/rtt_rosparam_tests/test/param_tests.cpp
@@ -668,19 +668,19 @@ TEST_F(ParamTest, AddRosParamDataSources)
   float in_float;
   int in_int;
   std::string in_string;
-  dynamic_cast<RTT::Property<bool>*>(tc->getProperty("bool_parameter"))->set(props.bool_);
+  tc->properties()->getPropertyType<bool>("bool_parameter")->set(props.bool_);
   ros::param::get("bool_parameter", in_bool);
   EXPECT_EQ(in_bool, props.bool_);
-  dynamic_cast<RTT::Property<double>*>(tc->getProperty("double_parameter"))->set(props.double_);
+  tc->properties()->getPropertyType<double>("double_parameter")->set(props.double_);
   ros::param::get("double_parameter", in_double);
   EXPECT_EQ(in_double, props.double_);
-  dynamic_cast<RTT::Property<float>*>(tc->getProperty("float_parameter"))->set(props.float_);
+  tc->properties()->getPropertyType<float>("float_parameter")->set(props.float_);
   ros::param::get("float_parameter", in_float);
   EXPECT_EQ(in_float, props.float_);
-  dynamic_cast<RTT::Property<int>*>(tc->getProperty("int_parameter"))->set(props.int_);
+  tc->properties()->getPropertyType<int>("int_parameter")->set(props.int_);
   ros::param::get("int_parameter", in_int);
   EXPECT_EQ(in_int, props.int_);
-  dynamic_cast<RTT::Property<std::string>*>(tc->getProperty("string_parameter"))->set(props.string_);
+  tc->properties()->getPropertyType<std::string>("string_parameter")->set(props.string_);
   ros::param::get("string_parameter", in_string);
   EXPECT_EQ(in_string, props.string_);
 }


### PR DESCRIPTION
# Description

This PR offers unit tests for the new `RosParamDataSource` from PR #148.

## Details

The unit test source related with `rtt_rosparam` in package `rtt_rosparam_tests` includes a new tests named `AddRosParamDataSources`. This particular test sets ROS parameters and creates properties using the new data source that link the evaluation and setting to the ROS parameter server.

* ROS paramters are read and checked from the unit test.
* ROS parameters are written out and check from the unit test.

## PR management

This PR makes the PR #150 obsolete. This new PR cherry-pics the contribution of PR #150 and then removes the code related with the closed PR #147.

Fixes https://github.com/orocos/rtt_ros_integration/issues/158.