### PR TITLE
rtt_roscomm: generate dependency typekits

### DIFF
--- a/rtt_roscomm/cmake/GenerateRTTROSCommPackage.cmake.em
+++ b/rtt_roscomm/cmake/GenerateRTTROSCommPackage.cmake.em
@@ -43,12 +43,68 @@ endmacro()
 
 macro(ros_generate_rtt_typekit package)
   cmake_parse_arguments(ros_generate_rtt_typekit "" "" "EXTRA_INCLUDES" ${ARGN})
-  set(_package ${package})
-  add_subdirectory(${rtt_roscomm_TEMPLATES_DIR}/typekit ${package}_typekit)
+
+  find_package(rtt_${package} QUIET)
+
+  if(NOT rtt_${package}_FOUND AND NOT TARGET rtt-${package}-typekit)
+    set(_include_dirs)
+    set(_pkg_libs)
+    set(_msg_exported_targets)
+    set(_typekit_targets)
+    set(_transport_targets)
+    set(_mqueue_targets)
+    set(_corba_targets)
+
+    include(${${package}_PREFIX}/${CATKIN_GLOBAL_SHARE_DESTINATION}/${package}/cmake/${package}-msg-paths.cmake)
+
+    foreach(dep ${${package}_MSG_DEPENDENCIES})
+      find_package(${dep} QUIET)
+
+      if(${dep}_FOUND)
+        list(APPEND _include_dirs ${${dep}_INCLUDE_DIRS})
+        list(APPEND _pkg_libs ${${dep}_LIBRARIES})
+        list(APPEND _msg_exported_targets ${${dep}_EXPORTED_TARGETS})
+
+        find_package(rtt_${dep} QUIET)
+
+        if(NOT rtt_${dep}_FOUND AND NOT TARGET rtt-${dep}-typekit)
+          ros_generate_rtt_typekit(${dep})
+        endif()
+        
+        if(rtt_${dep}_FOUND)
+          list(APPEND _pkg_libs ${rtt_${dep}_LIBRARIES})
+        endif()
+
+        if(TARGET rtt-${dep}-typekit)
+          list(APPEND _typekit_targets rtt-${dep}-typekit)
+        endif()
+
+        if(TARGET rtt-${dep}-ros-transport)
+          list(APPEND _transport_targets rtt-${dep}-ros-transport)
+        endif()
+
+        if(TARGET rtt-${dep}-ros-transport-mqueue)
+          list(APPEND _mqueue_targets rtt-${dep}-ros-transport-mqueue)
+        endif()
+
+        if(TARGET rtt-${dep}-ros-transport-corba)
+          list(APPEND _corba_targets rtt-${dep}-ros-transport-corba)
+        endif()
+      endif()
+    endforeach()
+
+    set(_package ${package})
+    add_subdirectory(${rtt_roscomm_TEMPLATES_DIR}/typekit ${package}_typekit)
+  endif()
 endmacro(ros_generate_rtt_typekit)
 
 macro(ros_generate_rtt_service_proxies package)
   cmake_parse_arguments(ros_generate_rtt_service_proxies "" "" "EXTRA_INCLUDES" ${ARGN})
-  set(_package ${package})
-  add_subdirectory(${rtt_roscomm_TEMPLATES_DIR}/service ${package}_service_proxies)
+
+  find_package(rtt_${package} QUIET)
+
+  if(NOT rtt_${package}_FOUND AND NOT TARGET rtt_${package}_rosservice_proxies)
+    set(_package ${package})
+    add_subdirectory(${rtt_roscomm_TEMPLATES_DIR}/service ${package}_service_proxies)
+  endif()
 endmacro(ros_generate_rtt_service_proxies)

--- a/rtt_roscomm/src/templates/service/CMakeLists.txt
+++ b/rtt_roscomm/src/templates/service/CMakeLists.txt
@@ -90,16 +90,17 @@ configure_file(
 include_directories(
   ${USE_OROCOS_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
-  ${${_package}_INCLUDE_DIRS})
+  ${${_package}_INCLUDE_DIRS}
+  ${_include_dirs})
 
 # Targets
 if(NOT DEFINED CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "Release")
   set(CMAKE_BUILD_TYPE MinSizeRel)
 endif()
 orocos_service(         rtt_${ROSPACKAGE}_rosservice_proxies ${CMAKE_CURRENT_BINARY_DIR}/rtt_rosservice_proxies.cpp)
-target_link_libraries(  rtt_${ROSPACKAGE}_rosservice_proxies ${catkin_LIBRARIES} ${USE_OROCOS_LIBRARIES})
+target_link_libraries(  rtt_${ROSPACKAGE}_rosservice_proxies ${catkin_LIBRARIES} ${_pkg_libs} ${USE_OROCOS_LIBRARIES})
 if(DEFINED ${_package}_EXPORTED_TARGETS)
-  add_dependencies(       rtt_${ROSPACKAGE}_rosservice_proxies ${${_package}_EXPORTED_TARGETS})
+  add_dependencies(       rtt_${ROSPACKAGE}_rosservice_proxies ${${_package}_EXPORTED_TARGETS} ${_msg_exported_targets})
 endif()
 
 get_directory_property(_additional_make_clean_files ADDITIONAL_MAKE_CLEAN_FILES)

--- a/rtt_roscomm/src/templates/typekit/CMakeLists.txt
+++ b/rtt_roscomm/src/templates/typekit/CMakeLists.txt
@@ -196,7 +196,8 @@ include_directories(
   ${rtt_roscomm_GENERATED_HEADERS_INSTALL_DESTINATION}/orocos
   ${USE_OROCOS_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
-  ${${_package}_INCLUDE_DIRS})
+  ${${_package}_INCLUDE_DIRS}
+  ${_include_dirs})
 
 # Targets
 if(NOT DEFINED CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "Release")
@@ -206,37 +207,37 @@ add_custom_target(rtt-${_package}-generate_boost_headers
   DEPENDS ${${_package}_GENERATED_BOOST_HEADERS}
 )
 orocos_typekit(rtt-${_package}-typekit ${rtt-${_package}-typekit_SOURCES})
-target_link_libraries(rtt-${_package}-typekit ${catkin_LIBRARIES} ${${_package}_LIBRARIES} ${USE_OROCOS_LIBRARIES})
-add_dependencies(rtt-${_package}-typekit rtt-${_package}-generate_boost_headers)
+target_link_libraries(rtt-${_package}-typekit ${catkin_LIBRARIES} ${${_package}_LIBRARIES} ${_pkg_libs} ${USE_OROCOS_LIBRARIES})
+add_dependencies(rtt-${_package}-typekit rtt-${_package}-generate_boost_headers ${_typekit_targets})
 orocos_typekit(rtt-${_package}-ros-transport ${rtt-${_package}-ros-transport_SOURCES})
-target_link_libraries(rtt-${_package}-ros-transport ${catkin_LIBRARIES} ${${_package}_LIBRARIES} ${USE_OROCOS_LIBRARIES})
-add_dependencies(rtt-${_package}-ros-transport rtt-${_package}-generate_boost_headers)
+target_link_libraries(rtt-${_package}-ros-transport ${catkin_LIBRARIES} ${${_package}_LIBRARIES} ${_pkg_libs} ${USE_OROCOS_LIBRARIES})
+add_dependencies(rtt-${_package}-ros-transport rtt-${_package}-generate_boost_headers ${_transport_targets})
 
 # Build mqueue transport plugin
 if(ENABLE_MQ)
   orocos_typekit(rtt-${_package}-ros-transport-mqueue ${rtt-${_package}-ros-transport-mqueue_SOURCES})
-  target_link_libraries(rtt-${_package}-ros-transport-mqueue ${catkin_LIBRARIES} ${${_package}_LIBRARIES} ${USE_OROCOS_LIBRARIES} ${OROCOS-RTT_MQUEUE_LIBRARIES})
-  add_dependencies(rtt-${_package}-ros-transport-mqueue rtt-${_package}-generate_boost_headers)
+  target_link_libraries(rtt-${_package}-ros-transport-mqueue ${catkin_LIBRARIES} ${${_package}_LIBRARIES} ${_pkg_libs} ${USE_OROCOS_LIBRARIES} ${OROCOS-RTT_MQUEUE_LIBRARIES})
+  add_dependencies(rtt-${_package}-ros-transport-mqueue rtt-${_package}-generate_boost_headers ${_mqueue_targets})
 endif()
 
 # Build corba transport plugin
 if(ENABLE_CORBA)
   orocos_typekit(rtt-${_package}-ros-transport-corba ${rtt-${_package}-ros-transport-corba_SOURCES})
-  target_link_libraries(rtt-${_package}-ros-transport-corba ${catkin_LIBRARIES} ${${_package}_LIBRARIES} ${USE_OROCOS_LIBRARIES} ${OROCOS-RTT_CORBA_LIBRARIES})
-  add_dependencies(rtt-${_package}-ros-transport-corba rtt-${_package}-generate_boost_headers)
+  target_link_libraries(rtt-${_package}-ros-transport-corba ${catkin_LIBRARIES} ${${_package}_LIBRARIES} ${_pkg_libs} ${USE_OROCOS_LIBRARIES} ${OROCOS-RTT_CORBA_LIBRARIES})
+  add_dependencies(rtt-${_package}-ros-transport-corba rtt-${_package}-generate_boost_headers ${_corba_targets})
 endif()
 
 # Add an explicit dependency between the typekits and message files
 # TODO: Add deps for all msg dependencies
-if(${_package}_EXPORTED_TARGETS)
+if(${_package}_EXPORTED_TARGETS OR DEFINED _msg_exported_targets)
   if(NOT ${_package} STREQUAL ${PROJECT_NAME})
-    add_dependencies(rtt-${_package}-typekit ${${_package}_EXPORTED_TARGETS})
-    add_dependencies(rtt-${_package}-ros-transport ${${_package}_EXPORTED_TARGETS})
+    add_dependencies(rtt-${_package}-typekit ${${_package}_EXPORTED_TARGETS} ${_msg_exported_targets})
+    add_dependencies(rtt-${_package}-ros-transport ${${_package}_EXPORTED_TARGETS} ${_msg_exported_targets})
     if(TARGET rtt-${_package}-ros-transport-mqueue)
-      add_dependencies(rtt-${_package}-ros-transport-mqueue ${${_package}_EXPORTED_TARGETS})
+      add_dependencies(rtt-${_package}-ros-transport-mqueue ${${_package}_EXPORTED_TARGETS} ${_msg_exported_targets})
     endif()
     if(TARGET rtt-${_package}-ros-transport-corba)
-      add_dependencies(rtt-${_package}-ros-transport-corba ${${_package}_EXPORTED_TARGETS})
+      add_dependencies(rtt-${_package}-ros-transport-corba ${${_package}_EXPORTED_TARGETS} ${_msg_exported_targets})
     endif()
   endif()
 endif()
@@ -244,7 +245,7 @@ endif()
 # Add the typekit libraries to the dependecies exported by this project
 #    LIST(APPEND ${PROJECT_NAME}_EXPORTED_TARGETS "rtt-${_package}-typekit")        # <-- This is already done in orocos_typekit().
 #    LIST(APPEND ${PROJECT_NAME}_EXPORTED_TARGETS "rtt-${_package}-ros-transport")  # <-- This is already done in orocos_typekit().
-LIST(APPEND ${PROJECT_NAME}_EXPORTED_INCLUDE_DIRS "${rtt_roscomm_GENERATED_HEADERS_OUTPUT_DIRECTORY}/orocos" ${${_package}_INCLUDE_DIRS})
+LIST(APPEND ${PROJECT_NAME}_EXPORTED_INCLUDE_DIRS "${rtt_roscomm_GENERATED_HEADERS_OUTPUT_DIRECTORY}/orocos" ${${_package}_INCLUDE_DIRS} ${_include_dirs})
 
 get_directory_property(_additional_make_clean_files ADDITIONAL_MAKE_CLEAN_FILES)
 list(APPEND _additional_make_clean_files "${rtt-${_package}-typekit_SOURCES};${rtt-${_package}-ros-transport_SOURCES};${rtt-${_package}-ros-transport-corba_SOURCES};${rtt-${_package}-ros-transport-mqueue_SOURCES};${rtt_roscomm_GENERATED_HEADERS_OUTPUT_DIRECTORY}/orocos/${_package}")


### PR DESCRIPTION
* When generating typekits, also generate them for all packages that the current package depends on for msg generation.
* Pass dependencies onto targets correctly so they are generated in the right order.
* Don't generate typekits or service proxies if they have already been generated (if there's a corresponding target or if the corresponding rtt_pkg already exists).

Closes #173 